### PR TITLE
Implement view pagination and some other niceness

### DIFF
--- a/example_site/content/blog/20180410 pagination.md
+++ b/example_site/content/blog/20180410 pagination.md
@@ -1,0 +1,17 @@
+Title: We have pagination!
+Date: 2018-04-10 02:25:25-07:00
+Entry-ID: 348
+UUID: af6d37d0-7ab4-46d8-996e-75b4f6bd22ac
+
+Something you might notice on [this very blog](/blog/) is that now there are only
+5 entries shown at a time by default, and there are handy links for the previous
+and next page.
+
+Another useful thing: [browsing by date](/blog/?date=2018-04-10), which also
+works on [months](/blog/?date=2018-04) and [years](/blog/?date=2018).
+
+There's still a bit of stuff that should be added but this was the second-to-last
+major thing to do before considering Publ useful enough for me to start migrating
+my own site over.
+
+Next up: Image renditions.

--- a/example_site/content/manual/Template format.md
+++ b/example_site/content/manual/Template format.md
@@ -239,8 +239,6 @@ The `category` object provides the following:
         * **`False`**: Only include direct subcategories (default)
         * **`True`**: Include all subcategories
 
-* **`subcats_recursive`**: All subcategories below this category
-
 * **`parent`**: The parent category, if any
 
 * **`link`**: The link to the category; optionally takes the

--- a/example_site/content/manual/Template format.md
+++ b/example_site/content/manual/Template format.md
@@ -1,5 +1,7 @@
-Title: Template format
+Title: Template API
 Path-Alias: /template-format
+Path-Alias: /template-api
+Path-Alias: /api
 Date: 2018-04-02 18:03:58-07:00
 Entry-ID: 324
 UUID: cbb977df-7902-4621-af9b-36ab44401748
@@ -75,6 +77,10 @@ The following additional things are provided to the request context:
     * **`before`**: Limit the view to only entries which came before the specified entry
     * **`after`**: Limit the view to only entries which came after the specified entry
 
+    * **`order`**: What order to provide the entries in; one of:
+        * **`oldest`**: Oldest-first
+        * **`newest`**: Newest-first (default)
+
 * **`static`**: Build a link to a static resource. The first argument is the path within the static
     resources directory; it also takes the following optional named arguments:
 
@@ -144,11 +150,13 @@ The `entry` object has the following methods/properties:
     These properties can be used directly, or they can take parameters,
     for example for [image renditions](/image-renditions).
 
+* **`date`**: The creation date and time of the entry
+
 * All headers on the [entry file](/entry-format) are available
 
-    These can be accessed either with `entry.header` or `entry['header']`. If
+    These can be accessed either with `entry.header` or `entry.get('header')`. If
     there is a `-` character in the header name you have to use the second
-    format, e.g. `entry['some-header']`.
+    format, e.g. `entry.get('some-header')`.
 
     If there is more than one header of that name, this will only retrieve
     one of them (and which one isn't defined); if you want to get all of them

--- a/example_site/content/manual/Template format.md
+++ b/example_site/content/manual/Template format.md
@@ -210,7 +210,7 @@ The `category` object provides the following:
 
 * **`parent`**: The parent category, if any
 
-* **`link`**: The link to the category; callable as a function which takes the
+* **`link`**: The link to the category; optionally takes the
     following arguments:
 
     * **`template`**: Which template to use when rendering the category
@@ -250,6 +250,17 @@ The `view` object has the following things on it:
 * **`last_modified`**: A last-modified time for this view (useful for feeds)
 
 * **`spec`**: The view's specification (category, limits, date range, etc.)
+
+* **`previous`**: The view of previous entries
+
+* **`next`**: The view of next entries
+
+* **`link`**: The link to this view; optionally takes the following arguments:
+
+    * **`template`**: Which template to use (defaults to the index template)
+    * **`absolute`**: Whether the URL should be absolute or relative
+        * **`False`**: Use a relative URL (default)
+        * **`True`**: Use an absolute URL
 
 It also takes arguments to further refine the view, using the same arguments
 as [`get_view()`](#fn-get-view); for example:

--- a/example_site/templates/blog/index.html
+++ b/example_site/templates/blog/index.html
@@ -30,7 +30,13 @@
 <div id="content">
     <div class="entries">
 
-        {% for entry in view(recurse=True,limit=5).entries %}
+        {% set flow = view(recurse=True,limit=5) %}
+
+        {% if flow.previous %}
+        <div class="nav"><a rel="previous" href="{{flow.previous.link}}">« Previous page</a>
+        {% endif %}
+
+        {% for entry in flow.entries %}
         <div class="entry">
             <h2><a href="{{entry.link}}">{{entry.title}}</a></h2>
             <div class="posted">Posted {{entry.date.format('dddd, MMMM D')}} at {{entry.date.format('h:mm A')}} ({{entry.date.humanize()}})
@@ -44,6 +50,11 @@
             {% endif %}
         </div>
         {% endfor %}
+
+        {% if flow.next %}
+        <div class="nav"><a rel="next" href="{{flow.next.link}}">Next page »</a>
+        {% endif %}
+
 
 </div>
 

--- a/example_site/templates/blog/index.html
+++ b/example_site/templates/blog/index.html
@@ -30,7 +30,7 @@
 <div id="content">
     <div class="entries">
 
-        {% for entry in view(recurse=True,limit=10).entries %}
+        {% for entry in view(recurse=True,limit=5).entries %}
         <div class="entry">
             <h2><a href="{{entry.link}}">{{entry.title}}</a></h2>
             <div class="posted">Posted {{entry.date.format('dddd, MMMM D')}} at {{entry.date.format('h:mm A')}} ({{entry.date.humanize()}})

--- a/example_site/templates/index.html
+++ b/example_site/templates/index.html
@@ -33,6 +33,15 @@
 
 <div id="content">
     <div class="entries">
+        {% set entries = view(entry_type_not='sidebar',limit=5) %}
+
+        {% if entries.previous %}
+        <a href="{{entries.previous.link}}">Previous entries</a>
+        {% endif %}
+
+        {% if entries.next %}
+        <a href="{{entries.next.link}}">Next entries</a>
+        {% endif %}
 
         {% for entry in view(entry_type_not='sidebar').entries %}
         <h2>

--- a/example_site/templates/sitemap.xml
+++ b/example_site/templates/sitemap.xml
@@ -5,7 +5,7 @@
     <url>
         <loc>{{category.link(absolute=True)}}</loc>
     </url>
-{%- for cat in category.subcats_recursive %}
+{%- for cat in category.subcats(recurse=True) %}
     <url>
         <loc>{{cat.link(absolute=True)}}</loc>
     </url>

--- a/example_site/templates/tests/bydate.html
+++ b/example_site/templates/tests/bydate.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Publ {{category.path or ''}}</title>
+    <link rel="stylesheet" href="{{ static('style.css') }}" />
+    <link rel="alternate" type="application/atom+xml" title="Atom feed" href="feed" />
+</head>
+<body>
+
+<h1>Publ: {{category.basename and category.basename.title() or "Yet another site generator"}}</h1>
+
+<div id="nav" class="sidebar">
+
+    <h2>Navigation</h2>
+
+    <ul>
+    {% if category.parent %}
+    <li class="cat-up"><a href="{{category.parent.link}}">Up one level</a></li>
+    {% endif %}
+
+    {% for subcat in category.subcats %}
+    <li class="cat-down"><a href="{{subcat.link}}">{{subcat.basename}}</a></li>
+    {% endfor %}
+
+    <li class="github"><a href="http://github.com/fluffy-critter/Publ">Github</a></li>
+
+    {% for entry in view(entry_type='sidebar').entries %}
+    <li class="sblink"><a href="{{entry.link}}">{{entry.title}}</a></li>
+    {% endfor %}
+    </ul>
+
+</div>
+
+<div id="content">
+<ul>
+{% for entry in entries %}
+<li><a href="{{entry.link}}">{{entry.title}}</a></li>
+{% endfor %}
+</ul>
+
+{% if view.previous %}
+<p>Previous: {{view.previous.link(absolute=True)}}</p>
+{% endif %}
+{% if view.next %}
+<p>Next: {{view.next.link(absolute=True)}}</p>
+{%endif %}
+
+</div>
+</body></html>

--- a/publ/category.py
+++ b/publ/category.py
@@ -24,6 +24,8 @@ class Category:
 
         self.link = utils.CallableProxy(self._link)
 
+        self.subcats = utils.CallableProxy(self._get_subcats)
+
     def _link(self, template='', absolute=False):
         return url_for('category',
             category=self.path,
@@ -39,26 +41,23 @@ class Category:
             self.parent = Category(self._parent) if (self._parent != None) else None
             return self.parent
 
-        if name == 'subcats':
-            # get all the subcategories, with only the first subdir added
+    def _get_subcats(self, recurse=False):
+        if recurse:
+            return [Category(e.category) for e in self._subcats_recursive]
 
-            # number of path components to ingest
-            parts = len(self.path.split('/')) + 1 if self.path else 1
+        # get all the subcategories, with only the first subdir added
 
-            # get the subcategories
-            subcats = [e.category for e in self._subcats_recursive]
+        # number of path components to ingest
+        parts = len(self.path.split('/')) + 1 if self.path else 1
 
-            # convert them into separated pathlists with only 'parts' parts
-            subcats = [c.split('/')[:parts] for c in subcats]
+        # get the subcategories
+        subcats = [e.category for e in self._subcats_recursive]
 
-            # join them back into a path, and make unique
-            subcats = {'/'.join(c) for c in subcats}
+        # convert them into separated pathlists with only 'parts' parts
+        subcats = [c.split('/')[:parts] for c in subcats]
 
-            # convert to a bunch of Category objects and bind to the Category
-            self.subcats = [Category(c) for c in sorted(subcats)]
-            return self.subcats
+        # join them back into a path, and make unique
+        subcats = {'/'.join(c) for c in subcats}
 
-        if name == 'subcats_recursive':
-            # convert the recursive subcats query to a property
-            self.subcats_recursive = [Category(e.category) for e in sorted(self._subcats_recursive)]
-            return self.subcats_recursive
+        # convert to a bunch of Category objects and bind to the Category
+        return [Category(c) for c in sorted(subcats)]

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -39,13 +39,6 @@ class Entry:
         if self._record.redirect_url:
             return self._record.redirect_url
 
-        # TODO https://github.com/fluffy-critter/Publ/issues/15
-        # if 'category' in kwargs or 'template' in kwargs:
-        #     return flask.get_url('category',
-        #         template=kwargs.get('template', ''),
-        #         category=kwargs.get('category', self._record.category,
-        #         start=self._record.id))
-
         return self._permalink(**kwargs)
 
     def _permalink(self, absolute=False, expand=True):

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -94,8 +94,6 @@ def get_entry(entry):
 
 ''' Generate a full where clause based on a restriction specification '''
 def build_query(spec):
-    print(spec)
-
     # primarily restrict by publication status
     if spec.get('future', False):
         where = where_entry_visible_future

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -1,8 +1,9 @@
 # queries.py
 # Collection of commonly-used queries
 
-from . import model
+from . import model, utils
 import arrow
+import re
 
 ''' Where clause for currently-visible entries '''
 where_entry_visible = (
@@ -46,6 +47,20 @@ def where_after_entry(entry):
         (model.Entry.id > entry.id)
     )
 
+''' Where clauses for entries where this is the last one '''
+def where_entry_last(entry):
+    return (model.Entry.entry_date < entry.entry_date) | (
+        (model.Entry.entry_date == entry.entry_date) &
+        (model.Entry.id <= entry.id)
+    )
+
+''' Where clause for entries where this is the first one '''
+def where_entry_first(entry):
+    return (model.Entry.entry_date > entry.entry_date) | (
+        (model.Entry.entry_date == entry.entry_date) &
+        (model.Entry.id >= entry.id)
+    )
+
 ''' Where clauses for entry type inclusion '''
 def where_entry_type(entry_type):
     if type(entry_type) == str:
@@ -60,8 +75,27 @@ def where_entry_type_not(entry_type):
     else:
         return (model.Entry.entry_type.not_in(entry_type))
 
+''' Where clauses for a date range '''
+def where_entry_date(datespec):
+    date, interval, _ = utils.parse_date(datespec)
+    start_date, end_date = date.span(interval)
+
+    print('date', date, interval)
+    print('range', start_date, end_date)
+
+    return ((model.Entry.entry_date >= start_date.datetime) &
+        (model.Entry.entry_date <= end_date.datetime))
+
+''' Get an entry by ID or by object '''
+def get_entry(entry):
+    if type(entry) == int or type(entry) == str:
+        return model.Entry.get(model.Entry.id == int(entry))
+    return entry
+
 ''' Generate a full where clause based on a restriction specification '''
 def build_query(spec):
+    print(spec)
+
     # primarily restrict by publication status
     if spec.get('future', False):
         where = where_entry_visible_future
@@ -79,5 +113,20 @@ def build_query(spec):
 
     if 'entry_type_not' in spec:
         where = where & where_entry_type_not(spec['entry_type_not'])
+
+    if 'date' in spec:
+        where = where & where_entry_date(spec['date'])
+
+    if 'last' in spec:
+        where = where & where_entry_last(get_entry(spec['last']))
+
+    if 'first' in spec:
+        where = where & where_entry_first(get_entry(spec['first']))
+
+    if 'before' in spec:
+        where = where & where_entry_before(get_entry(spec['before']))
+
+    if 'after' in spec:
+        where = where & where_query_after(get_entry(spec['after']))
 
     return where

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -99,9 +99,11 @@ def render_category(category='', template='index'):
         return render_error(category, 'Template not found', 400)
 
     # TODO https://github.com/fluffy-critter/Publ/issues/13
+    flat_args = {}
     view_obj = View({
         'category': category,
-        'date': request.args.get('date')
+        ## unfortunately **request.args doesn't work for some reason
+        **{k:v for k,v in request.args.items()}
         })
 
     return render_template(tmpl.filename,

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -83,7 +83,8 @@ def render_category(category='', template='index'):
 
     if category:
         # See if there's any entries for the view...
-        if not model.Entry.get_or_none((model.Entry.category == category) | (model.Entry.category.startswith(category + '/'))):
+        if not model.Entry.get_or_none((model.Entry.category == category) |
+            (model.Entry.category.startswith(category + '/'))):
             return render_error(category, 'Category not found', 404)
 
     tmpl = map_template(category, template)
@@ -98,14 +99,12 @@ def render_category(category='', template='index'):
         # nope, we just don't know what this is
         return render_error(category, 'Template not found', 400)
 
-    # TODO https://github.com/fluffy-critter/Publ/issues/13
-    flat_args = {}
-    view_obj = View({
-        'category': category,
-        ## unfortunately **request.args doesn't work for some reason
-        **{k:v for k,v in request.args.items()}
-        })
+    view_spec = {'category': category}
+    for key in ['date', 'last', 'first', 'before', 'after']:
+        if key in request.args:
+            view_spec[key] = request.args[key]
 
+    view_obj = View(view_spec)
     return render_template(tmpl.filename,
         category=Category(category),
         view=view_obj,

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -1,6 +1,9 @@
 # utils.py
 # Some useful utilities that don't belong anywhere else
 
+import config
+import re
+import arrow
 
 '''
 Wrapper class to make args possible on properties
@@ -37,3 +40,23 @@ class CallableProxy:
 
     def __str__(self):
         return str(self._get_default())
+
+'''
+Parse a date expression into a tuple:
+
+(start_date, span_type, span_format)
+'''
+def parse_date(datestr):
+    match = re.match(r'([0-9]{4})(-?([0-9]{1,2}))?(-?([0-9]{1,2}))?', datestr)
+    if not match:
+        return (arrow.get(datestr), 'day', 'YYYY-MM-DD')
+
+    year, month, day = match.group(1,3,5)
+    start = arrow.Arrow(year=int(year), month=int(month or 1), day=int(day or 1), tzinfo=config.timezone)
+
+    if day:
+        return start, 'day', 'YYYY-MM-DD'
+    elif month:
+        return start, 'month', 'YYYY-MM'
+    else:
+        return start, 'year', 'YYYY'

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -41,6 +41,9 @@ class CallableProxy:
     def __str__(self):
         return str(self._get_default())
 
+    def __iter__(self):
+        return self._get_default().__iter__()
+
 '''
 Parse a date expression into a tuple:
 

--- a/publ/view.py
+++ b/publ/view.py
@@ -30,15 +30,34 @@ sort - sorting spec, at the very least:
 future - whether to show entries from the future
 '''
 
+''' Prioritization list for page/offset/whatever '''
+offset_priority = ['date', 'last', 'first', 'before', 'after']
+
+''' Prioritization list for pagination type
+
+NOTE: date appears in here too so that if it appears as an offset it overrides the limit
+
+'''
+pagination_priority = ['date', 'limit']
+
 class View:
     def __init__(self, spec=None):
-        self.spec = spec
+        # filter out any priority override things
+        self.spec = {k:v for k,v in spec.items() if k not in offset_priority and k not in pagination_priority}
 
-        if 'date' in self.spec:
-            # date overrides limit
-            if 'limit' in self.spec: del self.spec['limit']
+        # pull in the first offset type that appears
+        for offset in offset_priority:
+            if offset in spec:
+                self.spec[offset] = spec[offset]
+                break
 
-        self._where = queries.build_query(spec or {})
+        # pull in the first page type that appears
+        for pagination in pagination_priority:
+            if pagination in spec:
+                self.spec[pagination] = spec[pagination]
+                break
+
+        self._where = queries.build_query(self.spec)
 
         self._query = model.Entry.select().where(self._where)
 
@@ -57,11 +76,24 @@ class View:
 
         self.link = utils.CallableProxy(self._link)
 
+    ''' Return a spec where all pagination stuff has been removed '''
+    def _spec_filtered(self):
+        return {k:v for k,v in self.spec.items()
+            if k not in offset_priority
+            and k not in pagination_priority}
+
     def __str__(self):
         return str(self._link())
 
     def _link(self, template='', absolute=False):
-        args = {k:v for k,v in self.spec.items() if k in ['date','last','first','before','after']}
+        args = {}
+        for k,v in self.spec.items():
+            if k in ['date','last','first','before','after']:
+                if type(v) == str or type(v) == int:
+                    args[k] = v
+                else:
+                    # the item was an object, so we actually want the object's id
+                    args[k] = v.id
 
         return flask.url_for('category',
             **args,
@@ -87,41 +119,92 @@ class View:
             self.previous, self.next = self._get_pagination()
             return getattr(self, name)
 
+    ''' Returns the views (if any) for the previous or next page, in that order
+
+    Note: "next page" is in terms of display order; newest first means next = older
+    '''
     def _get_pagination(self):
         if not self.entries or not len(self.entries):
             return None, None
 
+        if self._order_by == 'newest':
+            newest = self.entries[0]
+            oldest = self.entries[-1]
+        elif self._order_by == 'oldest':
+            oldest = self.entries[0]
+            newest = self.entries[-1]
+        else:
+            raise ValueError('pagination not supported on sort type {}'.format(self._order_by))
+
+        oldest_neighbor = oldest.previous
+        newest_neighbor = newest.next
+
+        base = self._spec_filtered()
+
         if 'limit' in self.spec:
-            # TODO
-            raise ValueError('limit pagination not yet supported')
+            # limiting by count
+            count = int(self.spec['limit'])
+
+            if self._order_by == 'newest':
+                # Newest first; next page ends at the one prior to our oldest
+                if oldest_neighbor:
+                    next_view = View({**base, 'last': oldest_neighbor})
+                else:
+                    next_view = None
+
+                # Previous page ends at [limit] after our newest
+                if newest_neighbor:
+                    # Ask for the next chunk of items in ascending order
+                    scan_view = View({**base,
+                        'first': newest_neighbor,
+                        'limit': count,
+                        'order': 'oldest'})
+                    # our previous page starts at the last entry (ascending)
+                    previous_view = View({**base, 'last': scan_view.entries[-1]})
+                else:
+                    previous_view = None
+
+                return previous_view, next_view
+
+            if self._order_by == 'oldest':
+                # Oldest first; next page begins with our newest entry
+                if newest_neighbor:
+                    next_view = View({**base, 'first': newest_neighbor})
+                else:
+                    next_view = None
+
+                # Previous page starts at [limit] before our newest
+                if oldest_neighbor:
+                    # Ask for the previous chunk of items in descending order
+                    scan_view = View({**base,
+                        'last': oldest_neighbor,
+                        'limit': count,
+                        'order': 'newest'})
+                    scan_entries = scan_view.entries
+                    # our previous page starts at the last entry (descending)
+                    previous_view = View({**base, 'first': scan_view.entries[-1]})
+                else:
+                    previous_view = None
+
+                return previous_view, next_view
 
         if 'date' in self.spec:
             # we're limiting by date
-            if self._order_by == 'newest':
-                newest = self.entries[0]
-                oldest = self.entries[-1]
-            elif self._order_by == 'oldest':
-                oldest = self.entries[0]
-                newest = self.entries[-1]
-            else:
-                raise ValueError('attempted date-based limit on non-date-based sort {}'.format(self._order_by))
-
-            previous_entry = oldest.previous
-            next_entry = newest.next
-
             _, _, format = utils.parse_date(self.spec['date'])
 
-            if previous_entry:
-                previous_date = previous_entry.date.format(format)
-                previous_view = View({**self.spec, 'date': previous_date})
+            if self._order_by == 'newest':
+                # newest first; next page contains the oldest neighbor
+                next_date = oldest_neighbor.date.format(format) if oldest_neighbor else None
+                previous_date = newest_neighbor.date.format(format) if newest_neighbor else None
+            elif self._order_by == 'oldest':
+                # oldest first; next page contains the newest neighbor
+                next_date = newest_neighbor.date.format(format) if newest_neighbor else None
+                previous_date = oldest_neighbor.date.format(format) if oldest_neighbor else None
             else:
-                previous_view = None
+                raise ValueError("Unsupported sort {} for date pagination".format(self._order_by))
 
-            if next_entry:
-                next_date = next_entry.date.format(format)
-                next_view = View({**self.spec, 'date': next_date})
-            else:
-                next_view = None
+            previous_view = View({**base, 'date': previous_date}) if previous_date else None
+            next_view = View({**base, 'date': next_date}) if next_date else None
 
             return previous_view, next_view
 

--- a/publ/view.py
+++ b/publ/view.py
@@ -4,6 +4,7 @@
 from . import model, utils, queries
 from .entry import Entry
 import arrow
+import flask
 
 '''
 TODO: figure out the actual API; https://github.com/fluffy-critter/Publ/issues/13
@@ -32,17 +33,45 @@ future - whether to show entries from the future
 class View:
     def __init__(self, spec=None):
         self.spec = spec
+
+        if 'date' in self.spec:
+            # date overrides limit
+            if 'limit' in self.spec: del self.spec['limit']
+
         self._where = queries.build_query(spec or {})
 
-        # TODO https://github.com/fluffy-critter/Publ/issues/13 sorting
-        self._query = model.Entry.select().where(self._where).order_by(-model.Entry.entry_date)
+        self._query = model.Entry.select().where(self._where)
 
         if 'limit' in spec:
-            self._query = self._query.limit(self.spec['limit'])
+            self._query = self._query.limit(spec['limit'])
+
+        self._order_by = spec.get('order', 'newest')
+        if self._order_by == 'newest':
+            self._order = -model.Entry.entry_date
+            self._reverse = model.Entry.entry_date
+        elif self._order_by == 'oldest':
+            self._order = model.Entry.entry_date
+            self._reverse = -model.Entry.entry_date
+        else:
+            raise ValueError("Unknown sort order '{}'".format(sort_order))
+
+        self.link = utils.CallableProxy(self._link)
+
+    def __str__(self):
+        return str(self._link())
+
+    def _link(self, template='', absolute=False):
+        args = {k:v for k,v in self.spec.items() if k in ['date','last','first','before','after']}
+
+        return flask.url_for('category',
+            **args,
+            template=template,
+            category=self.spec.get('category'),
+            _external=absolute)
 
     def __getattr__(self, name):
         if name == 'entries':
-            self.entries = [Entry(e) for e in self._query]
+            self.entries = [Entry(e) for e in self._query.order_by(self._order)]
             return self.entries
 
         if name == 'last_modified':
@@ -53,6 +82,51 @@ class View:
             except IndexError:
                 self.last_modified = arrow.get()
             return self.last_modified
+
+        if name == 'previous' or name == 'next':
+            self.previous, self.next = self._get_pagination()
+            return getattr(self, name)
+
+    def _get_pagination(self):
+        if not self.entries or not len(self.entries):
+            return None, None
+
+        if 'limit' in self.spec:
+            # TODO
+            raise ValueError('limit pagination not yet supported')
+
+        if 'date' in self.spec:
+            # we're limiting by date
+            if self._order_by == 'newest':
+                newest = self.entries[0]
+                oldest = self.entries[-1]
+            elif self._order_by == 'oldest':
+                oldest = self.entries[0]
+                newest = self.entries[-1]
+            else:
+                raise ValueError('attempted date-based limit on non-date-based sort {}'.format(self._order_by))
+
+            previous_entry = oldest.previous
+            next_entry = newest.next
+
+            _, _, format = utils.parse_date(self.spec['date'])
+
+            if previous_entry:
+                previous_date = previous_entry.date.format(format)
+                previous_view = View({**self.spec, 'date': previous_date})
+            else:
+                previous_view = None
+
+            if next_entry:
+                next_date = next_entry.date.format(format)
+                next_view = View({**self.spec, 'date': next_date})
+            else:
+                next_view = None
+
+            return previous_view, next_view
+
+        # we're not paginating?
+        return None, None
 
     def __call__(self, **restrict):
         return View({**self.spec, **restrict})


### PR DESCRIPTION
## Summary

Implements #13 and also cleans up `categories.subcats`

## Detailed description

Views with pagination restrictions (`limit`, `date`) now get `next` and `previous` properties
that refer to their neighboring views. Views also now have `link` which allows you to get a
link to the view in question.

## Developer/user impact

Any templates that used `category.subcats_recursive` now need to be changed to `category.subcats(recurse=True)`.

## Test plan

Added pagination to the blog and tests index templates, manually tested out `?date=` URLs.
