### PR TITLE
Add production-mode exception handler

### DIFF
--- a/example_site/content/manual/Template format.md
+++ b/example_site/content/manual/Template format.md
@@ -137,6 +137,10 @@ properties:
 
 * **`code`**: The associated HTTP error code
 * **`message`**: An explanation of what went wrong
+* **`exception`**: In the case of an internal error, this will be an object with the following properties:
+    * **`type`**: The human-readable type of exception (`IOError`, `ValueError`, etc.)
+    * **`str`**: The human-readable exception string
+    * **`args`**: Further information passed to the exception constructor
 
 ## Object interface
 

--- a/example_site/templates/error.html
+++ b/example_site/templates/error.html
@@ -19,11 +19,7 @@
     <li>endpoint: <code>{{request.endpoint}}</code></li>
     <li>url_rule: <code>{{request.url_rule}}</code></li>
 {% if exception %}
-    <li>Exception information: <code>{{exception.type}}</code> <ul>
-        {% for arg in exception.args %}
-        <li><code>{{arg}}</code></li>
-        {% endfor %}
-    </ul></li>
+    <li>Exception information: {{exception.type}}: {{exception.str}}</li>
 {% endif %}
 </ul>
 

--- a/example_site/templates/error.html
+++ b/example_site/templates/error.html
@@ -18,6 +18,13 @@
     <li>full_path: <code>{{request.full_path}}</code></li>
     <li>endpoint: <code>{{request.endpoint}}</code></li>
     <li>url_rule: <code>{{request.url_rule}}</code></li>
+{% if exception %}
+    <li>Exception information: <code>{{exception.type}}</code> <ul>
+        {% for arg in exception.args %}
+        <li><code>{{arg}}</code></li>
+        {% endfor %}
+    </ul></li>
+{% endif %}
 </ul>
 
 </body>

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -24,4 +24,7 @@ def setup(app):
 
     app.add_url_rule('/<path:path>.PUBL_PATHALIAS', 'path_alias', rendering.render_path_alias)
 
+    if not app.debug:
+        app.register_error_handler(Exception, rendering.render_exception)
+
     app.jinja_env.globals.update(get_view=view.get_view, arrow=arrow, static=rendering.static_url)

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -49,9 +49,11 @@ def static_url(path, absolute=False):
 def get_redirect():
     return path_alias.get_redirect([request.full_path, request.path])
 
-def render_error(category, error_message, *error_codes):
-    error_code = error_codes[0]
+def render_error(category, error_message, error_codes, exception=None):
+    if type(error_codes) == int:
+        error_codes = [error_codes]
 
+    error_code = error_codes[0]
     template_list = [str(code) for code in error_codes]
     template_list.append('error')
 
@@ -60,10 +62,19 @@ def render_error(category, error_message, *error_codes):
         return render_template(
             template.filename,
             error={'code':error_code, 'message':error_message},
+            exception=exception,
             template=template), error_code
 
     # no template found, so fall back to default Flask handler
     flask.abort(error_code)
+
+def render_exception(error):
+    _,_,category = str.partition(request.path, '/')
+    return render_error(category, "Exception occurred", 500, exception={
+        'type': type(error).__name__,
+        'str': str(error),
+        'args': error.args
+        })
 
 def render_path_alias(path):
     redir = path_alias.get_redirect('/' + path)

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -50,7 +50,7 @@ Parse a date expression into a tuple:
 (start_date, span_type, span_format)
 '''
 def parse_date(datestr):
-    match = re.match(r'([0-9]{4})(-?([0-9]{1,2}))?(-?([0-9]{1,2}))?', datestr)
+    match = re.match(r'([0-9]{4})(-?([0-9]{1,2}))?(-?([0-9]{1,2}))?$', datestr)
     if not match:
         return (arrow.get(datestr), 'day', 'YYYY-MM-DD')
 


### PR DESCRIPTION
## Summary

Fixes issue #5

## Detailed description

If `app.debug` isn't true, we now register a `rendering.render_exception` method as the default error handler for all `Exception`s.

## Test plan

Tested locally with: `pipenv run python3 main.py`

