### PR TITLE
Random ID sequences and ID deduping

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -9,9 +9,9 @@
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
-            "platform_release": "17.4.0",
+            "platform_release": "17.5.0",
             "platform_system": "Darwin",
-            "platform_version": "Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64",
+            "platform_version": "Darwin Kernel Version 17.5.0: Mon Mar  5 22:24:32 PST 2018; root:xnu-4570.51.1~1/RELEASE_X86_64",
             "python_full_version": "3.6.4",
             "python_version": "3.6",
             "sys_platform": "darwin"

--- a/example_site/content/blog/20180411 entry IDs.md
+++ b/example_site/content/blog/20180411 entry IDs.md
@@ -1,0 +1,112 @@
+Title: Let's talk about entry IDs
+Date: 2018-04-11 17:00:00-07:00
+Entry-ID: 276
+UUID: 4c0befa9-044b-4e38-948e-7fe869da0742
+
+So, previously I was just letting the database generate entry IDs on its own.
+In SQLite this means it would always generate the next entry ID as the highest
+one plus one. This is fine in a circumstance where entries always get assigned
+their IDs in the same place, but in Publ's model that might not be the case.
+
+One particularly fun circumstance: A site's maximum ID is 406.
+You've written an entry on your own machine,
+and someone else has written an entry on their own machine (or you wrote two
+entries, each on a separate branch), and when testing the rendering they both
+end up getting entry ID 407. Which one's right?
+
+.....
+
+Well, obviously, only one of them can have that entry ID. But the way Publ was
+set up, the entries would fight over that ID; whichever file was touched most
+recently would inherit the ID, and sorting it out could get really tricky.
+
+To that end I just implemented two strategies to prevent issues like this:
+
+* Collision reduction
+* Collision mitigation
+
+### Collision reduction
+
+One of the core problems is the simple auto-increment mechanism for generating
+IDs, which makes it very easy for multiple entries to be assigned the same ID.
+This also has the problem of making it very easy for a user of the site to guess
+about future entry IDs; if the most recent entry has ID 204 and they are impatient and want
+to peek ahead at scheduled posts, it's pretty likely that the next post will be 205.
+A scheduled post is still visible if you can guess the ID (by design), so we want
+to make it harder for people to guess.
+
+So, simply using a random number generator for ID generation seems pretty simple.
+But one of the core design goals of Publ is to keep URLs humane — and simply
+generating a random integer means that IDs will generally be around 9 digits long!
+That's not very humane at all!
+
+So, what this strategy does instead is it takes the number of entries, multiplies
+it by a constant factor ($$C$$ and adds another constant $$K$$, then uses that as a
+limit for the random number generation. Then it generates IDs until it finds one
+that isn't already taken.
+
+"But wait," you might ask, "doesn't that mean that you might have to generate an
+unbounded number of IDs before it finds one that's not taken?" Well, yes, this
+is true, but because of the load factor we can predict how many times this
+might have to happen. It's not worth going into the computation of this but
+suffice it to say that if you already have $$N$$ entries,
+it will take on average $$(N-K)/(NC-N)$$ attempts to find an unused ID.
+So for example, with $$N=5$$ and $$K=10$$ (which happen to be the values I've
+selected for now) and a site with 1000 entries, the average number of collisions
+per entry generated is $$0.2475$$ —
+that is, for every 4 entries created, only 1 will need a second ID generated.
+
+Also, since $$K$$ never changes and is small, as $$N$$ tends towards infinity the
+math converges on about $$1/(C-1)$$. (For that matter, $$K$$ is only even there to
+pad out the random range for smaller sites.)
+
+So, the nice thing about these constants is that the number of digits in an
+entry ID will be on the order of the number of digits of the number of entries,
+so if a site has 12,400 entries you can expect the entry ID to have around 5
+digits. (It's actually a bit larger; with $$N$$ entries the average number of
+digits will be around $$log_10(N) + log_10(C)$$, so with $$C=5$$ that's on average 0.7
+digits longer than the number of entries — so for example, if you have a 3-digit entry count,
+70% of your new entries will have a 4-digit ID).
+
+Wow, that was a lot of math. And Publ doesn't actually currently support math
+display correctly, oops. Guess I have to fix that. Well, [it's on the list](https://github.com/fluffy-critter/Publ/issues/40).
+
+### Collision mitigation
+
+So, even with all this in place, there's still a small chance that a colliding ID
+might be generated. Or maybe someone copied an entry file to use as a template but
+failed to remove the `Entry-ID` header. (Which means they also probably forgot to
+remove `UUID`, but one issue at a time!) So, how do we deal with that?
+
+Well, we could just see if an ID already exists when we ingest an entry, but
+that doesn't help on updating an entry that already exists.
+
+It's also possible that an entry changed filenames but didn't change IDs — and per
+Publ's design this means we need to keep the ID persistently.
+
+So, what we do now is when we scan an entry, if there's an ID on it that already
+exists in the index, and that existing entry has a different file path, we treat
+the entry as if it doesn't have an ID assigned in the file.
+
+There are probably some sequences of events where this isn't ideal, and this also
+doesn't solve the issue of merging two sites and figuring out how to deal with any
+internal permalinks which were used before. Well, it's a tough problem. (Fortunately
+the collision reduction strategy makes this less likely of a problem.)
+
+Really the best approach for permanently linking to another article on the site
+is to assign the article a `Path-Alias`. That is why on this example site, the
+major manual pages are given aliases like [`entry-format`](/entry-format) so that
+I don't have to worry about the IDs getting reassigned.
+
+### What else did I do today?
+
+Well, testing a bunch of collision reduction strategies took some time! I also
+tried to make some pretty graphs but didn't really have anything compelling to
+show for it in the end. Maybe I'll go back and add some when I have proper
+image renditions anyway.
+
+I also found another bug in view pagination; if there's a bunch of entries with
+the same date as each other, paginations were pretty much random because I didn't
+have the tiebreaker sort in the associated queries. So I fixed that.
+
+And I wrote this blog entry.

--- a/example_site/content/manual/Entry file format.md
+++ b/example_site/content/manual/Entry file format.md
@@ -63,8 +63,10 @@ templates; the following headers are what Publ itself uses:
     This can be in any
     format that [Arrow](http://arrow.readthedocs.io) understands. If no timezone
     is specified it will use the timezone indicated in `config.py`.
+    ([TODO](https://github.com/fluffy-critter/Publ/issues/41); this
+    is pending an [external fix](https://github.com/crsmithdev/arrow/pull/516))
 
-    **Default value**: the creation time of the entry (and will be added to the
+    **Default value**: the ctime of the entry file (which will be added to the
     file for later).
 
 * **`Category`**: Which category to put this entry in

--- a/example_site/content/tests/random-ids/entry1.md
+++ b/example_site/content/tests/random-ids/entry1.md
@@ -1,0 +1,7 @@
+Title: 1
+Date: 2017-01-01
+Entry-ID: 140
+UUID: b1992f0d-708f-4fc4-8d55-69e875e046e4
+
+.....
+Random ID 1

--- a/example_site/content/tests/random-ids/entry10.md
+++ b/example_site/content/tests/random-ids/entry10.md
@@ -1,0 +1,7 @@
+Title: 10
+Date: 2017-01-01
+Entry-ID: 13
+UUID: 25f93da7-f4d3-4d38-954c-1b0b9c3fdf6f
+
+.....
+Random ID 10

--- a/example_site/content/tests/random-ids/entry11.md
+++ b/example_site/content/tests/random-ids/entry11.md
@@ -1,0 +1,7 @@
+Title: 11
+Date: 2017-01-01
+Entry-ID: 129
+UUID: aaf20472-5be4-446d-9802-29957d9061b3
+
+.....
+Random ID 11

--- a/example_site/content/tests/random-ids/entry12.md
+++ b/example_site/content/tests/random-ids/entry12.md
@@ -1,0 +1,7 @@
+Title: 12
+Date: 2017-01-01
+Entry-ID: 59
+UUID: e7ca03bc-2a2d-4611-9cca-a23d097f46e6
+
+.....
+Random ID 12

--- a/example_site/content/tests/random-ids/entry13.md
+++ b/example_site/content/tests/random-ids/entry13.md
@@ -1,0 +1,7 @@
+Title: 13
+Date: 2017-01-01
+Entry-ID: 76
+UUID: e173e229-c1da-41d3-9eb4-d05691b7d114
+
+.....
+Random ID 13

--- a/example_site/content/tests/random-ids/entry14.md
+++ b/example_site/content/tests/random-ids/entry14.md
@@ -1,0 +1,7 @@
+Title: 14
+Date: 2017-01-01
+Entry-ID: 161
+UUID: e87d7323-635d-4e7f-b187-3af66bde68f2
+
+.....
+Random ID 14

--- a/example_site/content/tests/random-ids/entry15.md
+++ b/example_site/content/tests/random-ids/entry15.md
@@ -1,0 +1,7 @@
+Title: 15
+Date: 2017-01-01
+Entry-ID: 81
+UUID: 8a18851f-9238-4aea-924e-f728b0589f6f
+
+.....
+Random ID 15

--- a/example_site/content/tests/random-ids/entry16.md
+++ b/example_site/content/tests/random-ids/entry16.md
@@ -1,0 +1,7 @@
+Title: 16
+Date: 2017-01-01
+Entry-ID: 41
+UUID: 19d632f9-057e-42b9-a775-a85b41316653
+
+.....
+Random ID 16

--- a/example_site/content/tests/random-ids/entry17.md
+++ b/example_site/content/tests/random-ids/entry17.md
@@ -1,0 +1,7 @@
+Title: 17
+Date: 2017-01-01
+Entry-ID: 30
+UUID: b7a0e246-cd95-4432-bf1e-48cebdabcbb5
+
+.....
+Random ID 17

--- a/example_site/content/tests/random-ids/entry18.md
+++ b/example_site/content/tests/random-ids/entry18.md
@@ -1,0 +1,7 @@
+Title: 18
+Date: 2017-01-01
+Entry-ID: 183
+UUID: 5883998a-03fd-447f-872f-3ebbc6ae5e6f
+
+.....
+Random ID 18

--- a/example_site/content/tests/random-ids/entry19.md
+++ b/example_site/content/tests/random-ids/entry19.md
@@ -1,0 +1,7 @@
+Title: 19
+Date: 2017-01-01
+Entry-ID: 118
+UUID: 2f223a76-8191-4a71-87c0-792b330447ec
+
+.....
+Random ID 19

--- a/example_site/content/tests/random-ids/entry2.md
+++ b/example_site/content/tests/random-ids/entry2.md
@@ -1,0 +1,7 @@
+Title: 2
+Date: 2017-01-01
+Entry-ID: 126
+UUID: 0cb0026b-3074-4e74-8076-4b3dc5ad24c9
+
+.....
+Random ID 2

--- a/example_site/content/tests/random-ids/entry20.md
+++ b/example_site/content/tests/random-ids/entry20.md
@@ -1,0 +1,7 @@
+Title: 20
+Date: 2017-01-01
+Entry-ID: 182
+UUID: 4df1b526-13ef-473e-9279-ab60b0ee7f00
+
+.....
+Random ID 20

--- a/example_site/content/tests/random-ids/entry21.md
+++ b/example_site/content/tests/random-ids/entry21.md
@@ -1,0 +1,7 @@
+Title: 21
+Date: 2017-01-01
+Entry-ID: 42
+UUID: 974033d4-3b3f-41b5-ba62-082454f98325
+
+.....
+Random ID 21

--- a/example_site/content/tests/random-ids/entry22.md
+++ b/example_site/content/tests/random-ids/entry22.md
@@ -1,0 +1,7 @@
+Title: 22
+Date: 2017-01-01
+Entry-ID: 131
+UUID: 940c646b-f675-4487-ae5b-7fbd16c66a61
+
+.....
+Random ID 22

--- a/example_site/content/tests/random-ids/entry23.md
+++ b/example_site/content/tests/random-ids/entry23.md
@@ -1,0 +1,7 @@
+Title: 23
+Date: 2017-01-01
+Entry-ID: 106
+UUID: b3f08baf-c527-4674-99d1-d0b7a17a7244
+
+.....
+Random ID 23

--- a/example_site/content/tests/random-ids/entry24.md
+++ b/example_site/content/tests/random-ids/entry24.md
@@ -1,0 +1,7 @@
+Title: 24
+Date: 2017-01-01
+Entry-ID: 25
+UUID: 2b78cc26-259c-414c-b550-98f7ed0127dc
+
+.....
+Random ID 24

--- a/example_site/content/tests/random-ids/entry25.md
+++ b/example_site/content/tests/random-ids/entry25.md
@@ -1,0 +1,7 @@
+Title: 25
+Date: 2017-01-01
+Entry-ID: 63
+UUID: 51d38833-1033-4891-993b-aabf7cd76c75
+
+.....
+Random ID 25

--- a/example_site/content/tests/random-ids/entry26.md
+++ b/example_site/content/tests/random-ids/entry26.md
@@ -1,0 +1,7 @@
+Title: 26
+Date: 2017-01-01
+Entry-ID: 199
+UUID: 5722f61b-2df1-4958-a838-2e9bd0ee8782
+
+.....
+Random ID 26

--- a/example_site/content/tests/random-ids/entry27.md
+++ b/example_site/content/tests/random-ids/entry27.md
@@ -1,0 +1,7 @@
+Title: 27
+Date: 2017-01-01
+Entry-ID: 43
+UUID: 7bf7c573-0e7b-4b2b-81c5-8d284f6df835
+
+.....
+Random ID 27

--- a/example_site/content/tests/random-ids/entry28.md
+++ b/example_site/content/tests/random-ids/entry28.md
@@ -1,0 +1,7 @@
+Title: 28
+Date: 2017-01-01
+Entry-ID: 205
+UUID: 16dcc146-eee7-458a-9e5a-0f52cc7e2f91
+
+.....
+Random ID 28

--- a/example_site/content/tests/random-ids/entry29.md
+++ b/example_site/content/tests/random-ids/entry29.md
@@ -1,0 +1,7 @@
+Title: 29
+Date: 2017-01-01
+Entry-ID: 240
+UUID: a14c2af4-fbdd-420a-9832-15b6cba6a348
+
+.....
+Random ID 29

--- a/example_site/content/tests/random-ids/entry3.md
+++ b/example_site/content/tests/random-ids/entry3.md
@@ -1,0 +1,7 @@
+Title: 3
+Date: 2017-01-01
+Entry-ID: 248
+UUID: 75f7ddd4-0243-4a9e-bbe7-c5bf0165d2ed
+
+.....
+Random ID 3

--- a/example_site/content/tests/random-ids/entry30.md
+++ b/example_site/content/tests/random-ids/entry30.md
@@ -1,0 +1,7 @@
+Title: 30
+Date: 2017-01-01
+Entry-ID: 226
+UUID: 6f5a944f-f954-4a77-8584-dd1191a6b401
+
+.....
+Random ID 30

--- a/example_site/content/tests/random-ids/entry31.md
+++ b/example_site/content/tests/random-ids/entry31.md
@@ -1,0 +1,7 @@
+Title: 31
+Date: 2017-01-01
+Entry-ID: 167
+UUID: ad787484-003d-4062-a2dc-49b10bd3d305
+
+.....
+Random ID 31

--- a/example_site/content/tests/random-ids/entry32.md
+++ b/example_site/content/tests/random-ids/entry32.md
@@ -1,0 +1,7 @@
+Title: 32
+Date: 2017-01-01
+Entry-ID: 73
+UUID: 30f938ff-81e5-41a4-8982-02e63841cb54
+
+.....
+Random ID 32

--- a/example_site/content/tests/random-ids/entry33.md
+++ b/example_site/content/tests/random-ids/entry33.md
@@ -1,0 +1,7 @@
+Title: 33
+Date: 2017-01-01
+Entry-ID: 9
+UUID: b001453b-365b-43e5-bb45-58ad17eabba5
+
+.....
+Random ID 33

--- a/example_site/content/tests/random-ids/entry34.md
+++ b/example_site/content/tests/random-ids/entry34.md
@@ -1,0 +1,7 @@
+Title: 34
+Date: 2017-01-01
+Entry-ID: 48
+UUID: 49ac804d-15c5-4ba5-838e-3870c916c00e
+
+.....
+Random ID 34

--- a/example_site/content/tests/random-ids/entry35.md
+++ b/example_site/content/tests/random-ids/entry35.md
@@ -1,0 +1,7 @@
+Title: 35
+Date: 2017-01-01
+Entry-ID: 130
+UUID: 482aba48-3a8f-41ca-b51c-3813159b8780
+
+.....
+Random ID 35

--- a/example_site/content/tests/random-ids/entry36.md
+++ b/example_site/content/tests/random-ids/entry36.md
@@ -1,0 +1,7 @@
+Title: 36
+Date: 2017-01-01
+Entry-ID: 117
+UUID: 55800ca4-f1db-4fd6-822f-a1d986fef0e7
+
+.....
+Random ID 36

--- a/example_site/content/tests/random-ids/entry37.md
+++ b/example_site/content/tests/random-ids/entry37.md
@@ -1,0 +1,7 @@
+Title: 37
+Date: 2017-01-01
+Entry-ID: 47
+UUID: 4cfee2bc-ff1a-490b-8c2b-08a061a594ca
+
+.....
+Random ID 37

--- a/example_site/content/tests/random-ids/entry38.md
+++ b/example_site/content/tests/random-ids/entry38.md
@@ -1,0 +1,7 @@
+Title: 38
+Date: 2017-01-01
+Entry-ID: 255
+UUID: 6e38b231-e946-4c10-9e34-d43cd753a2e7
+
+.....
+Random ID 38

--- a/example_site/content/tests/random-ids/entry39.md
+++ b/example_site/content/tests/random-ids/entry39.md
@@ -1,0 +1,7 @@
+Title: 39
+Date: 2017-01-01
+Entry-ID: 206
+UUID: 9a5b31e4-5171-42c7-9de4-fed2c5b4a0cd
+
+.....
+Random ID 39

--- a/example_site/content/tests/random-ids/entry4.md
+++ b/example_site/content/tests/random-ids/entry4.md
@@ -1,0 +1,7 @@
+Title: 4
+Date: 2017-01-01
+Entry-ID: 67
+UUID: 70bc9f6c-02d7-4ea0-bfbe-5f08d4ba2783
+
+.....
+Random ID 4

--- a/example_site/content/tests/random-ids/entry40.md
+++ b/example_site/content/tests/random-ids/entry40.md
@@ -1,0 +1,7 @@
+Title: 40
+Date: 2017-01-01
+Entry-ID: 210
+UUID: aa2055ef-f4f6-4e41-94d5-e1867bddc6fc
+
+.....
+Random ID 40

--- a/example_site/content/tests/random-ids/entry41.md
+++ b/example_site/content/tests/random-ids/entry41.md
@@ -1,0 +1,7 @@
+Title: 41
+Date: 2017-01-01
+Entry-ID: 245
+UUID: 90b985d8-1d5b-4703-8ead-1f8ef9892830
+
+.....
+Random ID 41

--- a/example_site/content/tests/random-ids/entry42.md
+++ b/example_site/content/tests/random-ids/entry42.md
@@ -1,0 +1,7 @@
+Title: 42
+Date: 2017-01-01
+Entry-ID: 284
+UUID: 08c6d1be-080d-4724-aace-4a40f8b566bc
+
+.....
+Random ID 42

--- a/example_site/content/tests/random-ids/entry43.md
+++ b/example_site/content/tests/random-ids/entry43.md
@@ -1,0 +1,7 @@
+Title: 43
+Date: 2017-01-01
+Entry-ID: 80
+UUID: 8794c1e2-9a43-4fd2-996d-e65cd7d4296d
+
+.....
+Random ID 43

--- a/example_site/content/tests/random-ids/entry44.md
+++ b/example_site/content/tests/random-ids/entry44.md
@@ -1,0 +1,7 @@
+Title: 44
+Date: 2017-01-01
+Entry-ID: 37
+UUID: c4e0ea54-8d8a-4182-ab6a-4a317ddba9ed
+
+.....
+Random ID 44

--- a/example_site/content/tests/random-ids/entry45.md
+++ b/example_site/content/tests/random-ids/entry45.md
@@ -1,0 +1,7 @@
+Title: 45
+Date: 2017-01-01
+Entry-ID: 86
+UUID: 7bcbaa6a-7daa-437e-b1bb-56965a182612
+
+.....
+Random ID 45

--- a/example_site/content/tests/random-ids/entry46.md
+++ b/example_site/content/tests/random-ids/entry46.md
@@ -1,0 +1,7 @@
+Title: 46
+Date: 2017-01-01
+Entry-ID: 196
+UUID: 46130df0-c533-4d64-9004-f1d18ce38786
+
+.....
+Random ID 46

--- a/example_site/content/tests/random-ids/entry47.md
+++ b/example_site/content/tests/random-ids/entry47.md
@@ -1,0 +1,7 @@
+Title: 47
+Date: 2017-01-01
+Entry-ID: 229
+UUID: 09b29829-c85b-42d7-b03d-7551fff6969f
+
+.....
+Random ID 47

--- a/example_site/content/tests/random-ids/entry48.md
+++ b/example_site/content/tests/random-ids/entry48.md
@@ -1,0 +1,7 @@
+Title: 48
+Date: 2017-01-01
+Entry-ID: 172
+UUID: ff69872d-d771-4f4f-8765-10dfb4a608f2
+
+.....
+Random ID 48

--- a/example_site/content/tests/random-ids/entry49.md
+++ b/example_site/content/tests/random-ids/entry49.md
@@ -1,0 +1,7 @@
+Title: 49
+Date: 2017-01-01
+Entry-ID: 209
+UUID: af39d16a-2e67-495a-93ad-b31e21f1a9cd
+
+.....
+Random ID 49

--- a/example_site/content/tests/random-ids/entry5.md
+++ b/example_site/content/tests/random-ids/entry5.md
@@ -1,0 +1,7 @@
+Title: 5
+Date: 2017-01-01
+Entry-ID: 355
+UUID: 196945c6-a90d-4af3-8fef-386903ceb9c2
+
+.....
+Random ID 5

--- a/example_site/content/tests/random-ids/entry50.md
+++ b/example_site/content/tests/random-ids/entry50.md
@@ -1,0 +1,7 @@
+Title: 50
+Date: 2017-01-01
+Entry-ID: 166
+UUID: 6bbebf61-9aba-4233-a300-e81df7dcf4a5
+
+.....
+Random ID 50

--- a/example_site/content/tests/random-ids/entry6.md
+++ b/example_site/content/tests/random-ids/entry6.md
@@ -1,0 +1,7 @@
+Title: 6
+Date: 2017-01-01
+Entry-ID: 61
+UUID: d1643c34-a123-4a0c-a26c-eb987ee69260
+
+.....
+Random ID 6

--- a/example_site/content/tests/random-ids/entry7.md
+++ b/example_site/content/tests/random-ids/entry7.md
@@ -1,0 +1,7 @@
+Title: 7
+Date: 2017-01-01
+Entry-ID: 243
+UUID: d911ea5e-e32d-420e-8da6-254d3a45e35d
+
+.....
+Random ID 7

--- a/example_site/content/tests/random-ids/entry8.md
+++ b/example_site/content/tests/random-ids/entry8.md
@@ -1,0 +1,7 @@
+Title: 8
+Date: 2017-01-01
+Entry-ID: 247
+UUID: 3f03c739-4673-4772-8dc5-84daf078926c
+
+.....
+Random ID 8

--- a/example_site/content/tests/random-ids/entry9.md
+++ b/example_site/content/tests/random-ids/entry9.md
@@ -1,0 +1,7 @@
+Title: 9
+Date: 2017-01-01
+Entry-ID: 364
+UUID: 2c2232b3-8238-4cb0-979b-ab0e2bde419c
+
+.....
+Random ID 9

--- a/example_site/templates/blog/entry.html
+++ b/example_site/templates/blog/entry.html
@@ -32,7 +32,7 @@
     <div class="entries">
         <div class="entry">
             <h2>{{entry.title}}</h2>
-            <div class="posted">Posted {{entry.date.format('dddd, MMMM D')}} at {{entry.date.format('h:mm A')}} ({{entry.date.humanize()}})
+            <div class="posted">Posted {{entry.date.format('dddd, MMMM D')}} at {{entry.date.format('h:mm A Z')}} ({{entry.date.humanize()}})
                 {% if entry.author %}by {{entry.author}}{% endif %}
                 {% if entry.last_modified > entry.date and entry.last_modified.humanize() != entry.date.humanize() %}
                     <div class="update">Last updated {{entry.last_modified.humanize()}}</div>

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -151,7 +151,8 @@ class Entry:
 ''' convert a title into a URL-friendly slug '''
 def make_slug(title):
     # TODO https://github.com/fluffy-critter/Publ/issues/16
-    # this should probably handle things other than English ASCII...
+    # this should probably handle things other than English ASCII, and also
+    # some punctuation should just be outright removed (quotes/apostrophes/etc)
     return re.sub(r"[^a-zA-Z0-9.]+", r" ", title).strip().replace(' ','-')
 
 ''' Attempt to guess the title from the filename '''
@@ -223,7 +224,9 @@ def scan_file(fullpath, relpath, assign_id):
         }
 
         if 'Date' in entry:
-            entry_date = arrow.get(entry['Date'])
+            entry_date = arrow.get(entry['Date'], tzinfo=config.timezone)
+            del entry['Date']
+            entry['Date'] = entry_date.format()
         else:
             entry_date = arrow.get(os.stat(fullpath).st_ctime).to(config.timezone)
             entry['Date'] = entry_date.format()

--- a/publ/view.py
+++ b/publ/view.py
@@ -44,11 +44,9 @@ class View:
 
         self._order_by = spec.get('order', 'newest')
         if self._order_by == 'newest':
-            self._order = -model.Entry.entry_date
-            self._reverse = model.Entry.entry_date
+            self._order = [-model.Entry.entry_date, -model.Entry.id]
         elif self._order_by == 'oldest':
-            self._order = model.Entry.entry_date
-            self._reverse = -model.Entry.entry_date
+            self._order = [model.Entry.entry_date, model.Entry.id]
         else:
             raise ValueError("Unknown sort order '{}'".format(sort_order))
 
@@ -81,7 +79,7 @@ class View:
 
     def __getattr__(self, name):
         if name == 'entries':
-            self.entries = [Entry(e) for e in self._query.order_by(self._order)]
+            self.entries = [Entry(e) for e in self._query.order_by(*self._order)]
             return self.entries
 
         if name == 'last_modified':


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Implements ID deduping and random ID sequences, as per issue #39 

## Detailed description

* Randomizes entry ID sequences to avoid collisions
* If a collision does happen, semi-intelligently reassigns the conflicting entries
* Fix some pagination bugs this exposed

## Developer/user impact

Entry IDs are now explicitly NOT sequential.

## Test plan

Created a bunch of random entries with no ID.

Created a bunch of random entries with the same ID.

Both worked.

