### PR TITLE
Enable math rendering via MathJax

### DIFF
--- a/example_site/content/blog/20180411 entry IDs.md
+++ b/example_site/content/blog/20180411 entry IDs.md
@@ -41,7 +41,7 @@ generating a random integer means that IDs will generally be around 9 digits lon
 That's not very humane at all!
 
 So, what this strategy does instead is it takes the number of entries, multiplies
-it by a constant factor ($$C$$ and adds another constant $$K$$, then uses that as a
+it by a constant factor \\(C\\) and adds another constant \\(K\\), then uses that as a
 limit for the random number generation. Then it generates IDs until it finds one
 that isn't already taken.
 
@@ -49,27 +49,28 @@ that isn't already taken.
 unbounded number of IDs before it finds one that's not taken?" Well, yes, this
 is true, but because of the load factor we can predict how many times this
 might have to happen. It's not worth going into the computation of this but
-suffice it to say that if you already have $$N$$ entries,
-it will take on average $$(N-K)/(NC-N)$$ attempts to find an unused ID.
-So for example, with $$N=5$$ and $$K=10$$ (which happen to be the values I've
+suffice it to say that if you already have \\(N\\) entries,
+it will take on average \\(\frac{N}{(N+K)(C-1)}\\) attempts to find an unused ID.
+So for example, with \\(C=5\\) and \\(K=10\\) (which happen to be the values I've
 selected for now) and a site with 1000 entries, the average number of collisions
-per entry generated is $$0.2475$$ —
+per entry generated is \\( \approx 0.2475 \\) —
 that is, for every 4 entries created, only 1 will need a second ID generated.
 
-Also, since $$K$$ never changes and is small, as $$N$$ tends towards infinity the
-math converges on about $$1/(C-1)$$. (For that matter, $$K$$ is only even there to
+Also, since \\(K\\) never changes and is small, as \\(N\\) tends towards infinity the
+math converges on about \\(\frac{1}{C-1}\\). (For that matter, \\(K\\) is only even there to
 pad out the random range for smaller sites.)
 
 So, the nice thing about these constants is that the number of digits in an
 entry ID will be on the order of the number of digits of the number of entries,
 so if a site has 12,400 entries you can expect the entry ID to have around 5
-digits. (It's actually a bit larger; with $$N$$ entries the average number of
-digits will be around $$log_10(N) + log_10(C)$$, so with $$C=5$$ that's on average 0.7
+digits. (It's actually a bit larger; with \\(N\\) entries the average number of
+digits will be around \\(log(N) + log(C)\\), so with \\(C=5\\) that's on average 0.7
 digits longer than the number of entries — so for example, if you have a 3-digit entry count,
 70% of your new entries will have a 4-digit ID).
 
-Wow, that was a lot of math. And Publ doesn't actually currently support math
-display correctly, oops. Guess I have to fix that. Well, [it's on the list](https://github.com/fluffy-critter/Publ/issues/40).
+Wow, that was a lot of math. ~~And Publ doesn't actually currently support math
+display correctly, oops. Guess I have to fix that. Well, [it's on the list](https://github.com/fluffy-critter/Publ/issues/40).~~ Turns out that Misaka is designed to work with [MathJax](https://www.mathjax.org), so
+that one was easy to cross off.
 
 ### Collision mitigation
 

--- a/example_site/content/manual/Entry file format.md
+++ b/example_site/content/manual/Entry file format.md
@@ -152,11 +152,12 @@ After the headers, you can have entry content; if the file has a `.htm` or `.htm
 extension it will just render as plain HTML, but with a `.md` extension it will
 render as [Markdown](https://en.wikipedia.org/wiki/Markdown).
 
-Publ supports [GitHub-flavored markdown](https://guides.github.com/features/mastering-markdown/),
-as well as some Publ-specific tags for things like cuts, image renditions, and galleries.
+Publ supports [GitHub-flavored markdown](https://guides.github.com/features/mastering-markdown/), specifically via [Misaka](http://misaka.61924.nl) (which in turn uses [Hoedown](https://github.com/hoedown/hoedown) — my, Earth certainly is full of things!).
 
 Code highlighting uses the [Pygments](http://pygments.org) library, which supports
 [a rather large list of syntaxes](http://pygments.org/docs/lexers/).
+
+There are also some Publ-specific extensions for things like cuts, image renditions, and galleries.
 
 ### Custom tags
 

--- a/example_site/templates/blog/entry.html
+++ b/example_site/templates/blog/entry.html
@@ -2,7 +2,12 @@
 <html>
 <head>
     <title>{{entry['title'] | safe}}</title>
+
     <link rel="stylesheet" href="{{ static('style.css') }}">
+
+    <!-- Include MathJax to support math rendering -->
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML' async></script>
+
 </head>
 <body>
 <h1><a href="{{category.link}}">Publ: {{category.basename.title() }}</a></h1>

--- a/example_site/templates/blog/index.html
+++ b/example_site/templates/blog/index.html
@@ -4,6 +4,7 @@
     <title>Publ {{category.basename.title()}}</title>
     <link rel="stylesheet" href="{{ static('style.css') }}" />
     <link rel="alternate" type="application/atom+xml" title="Atom feed" href="feed" />
+    <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-MML-AM_CHTML' async></script>
 </head>
 <body>
 


### PR DESCRIPTION
Fixes issue #40. Turns out MathJax makes this really easy; it's dependent on the template providing the MathJax JavaScript include.