### PR TITLE
Implement basic caching

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ peewee = "*"
 arrow = "*"
 misaka = "*"
 pygments = "*"
+flask-cache = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,18 +1,18 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e5f348c43dc17dc2c39cdadc74603ffbcba85bc76188200e197b68b419931c30"
+            "sha256": "7335247081d814d1f64f1d332f0e67505f10187243acf3ae6ee7947411126555"
         },
         "host-environment-markers": {
             "implementation_name": "cpython",
-            "implementation_version": "3.6.4",
+            "implementation_version": "3.6.5",
             "os_name": "posix",
             "platform_machine": "x86_64",
             "platform_python_implementation": "CPython",
             "platform_release": "17.5.0",
             "platform_system": "Darwin",
             "platform_version": "Darwin Kernel Version 17.5.0: Mon Mar  5 22:24:32 PST 2018; root:xnu-4570.51.1~1/RELEASE_X86_64",
-            "python_full_version": "3.6.4",
+            "python_full_version": "3.6.5",
             "python_version": "3.6",
             "sys_platform": "darwin"
         },
@@ -44,10 +44,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:14131608ad2fd56836d33a71ee60fa1c82bc9d2c8d98b7bdbc631fe1b3cd1296",
-                "sha256:edbc3f203427eef571f79a7692bb160a2b0f7ccaa31953e99bd17e307cf63f7d"
+                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0",
+                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7"
             ],
-            "version": "==2018.1.18"
+            "version": "==2018.4.16"
         },
         "cffi": {
             "hashes": [
@@ -102,6 +102,14 @@
             ],
             "version": "==0.12.2"
         },
+        "flask-cache": {
+            "hashes": [
+                "sha256:33187b3ddceeee233fe3db68ffcc118b5498e8ad28edde711bcbdcbf4924ce35",
+                "sha256:ae9d1ac4549517dfbc1f178ccc5429f61f836be3cc109a0b2481c98b3711c329",
+                "sha256:90126ca9bc063854ef8ee276e95d38b2b4ec8e45fd77d5751d37971ee27c7ef4"
+            ],
+            "version": "==0.13.1"
+        },
         "idna": {
             "hashes": [
                 "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4",
@@ -142,9 +150,9 @@
         },
         "peewee": {
             "hashes": [
-                "sha256:e31771a5a18576336eaf7883d1b4bfd9478d0af02ff5a8f932ec1c5ef56ca7e5"
+                "sha256:66dccc1c4db0c0234f23fbe9ba44ad99aed8e8d8c09c6b28e85d482312f0f242"
             ],
-            "version": "==3.2.2"
+            "version": "==3.2.3"
         },
         "pycparser": {
             "hashes": [

--- a/config.py.dist
+++ b/config.py.dist
@@ -27,6 +27,13 @@ template_directory = 'example_site/templates'
 # Where our site content lives
 content_directory = 'example_site/content'
 
+# Cache; see https://pythonhosted.org/Flask-Cache/ for more information
+cache = {
+    'CACHE_TYPE': 'simple',
+    'CACHE_DEFAULT_TIMEOUT': 300,
+    'CACHE_THRESHOLD': 100
+}
+
 # In-memory database; fastest but most memory-intensive
 # also for some reason peewee keeps dropping it? WTF
 #database = "sqlite:///:memory:"

--- a/example_site/content/blog/20180416 caching.md
+++ b/example_site/content/blog/20180416 caching.md
@@ -1,0 +1,28 @@
+Title: Added some basic caching
+UUID: cd44010c-39a8-4aa0-b702-3b0d30a68715
+Date: 2018-04-16 20:00:00-07:00
+Entry-ID: 134
+
+Instead of working on image renditions I decided to try adding in some caching
+functionality, and experimented with both `functools.lru_cache` and
+[Flask-Cache](https://pythonhosted.org/Flask-Cache/). Neither is a particularly
+great solution to caching but they get the job done.
+
+.....
+
+Currently caching uses Flask-Cache for for template resolution and rendered categories,
+and `functools.lru_cache` for entry content loading; unfortunately since content
+might need to be loaded in the watchdog process (which doesn't run under Flask)
+that couldn't go through Flask-Cache.
+
+Unfortunately, this didn't seem to speed anything up on Dreamhost, meaning that
+the performance issue there is probably with the fronting Passenger server and
+not with I/O limitations on the Publ process.
+
+I haven't done any major performance testing though, I've just gone based on
+how it feels. A full analysis can come later. Fortunately, Flask-Cache makes it
+pretty easy to turn the cache on or off so measuring it won't be too hard,
+I don't think.
+
+I keep saying "image renditions are the next thing I'll work on" and then I end
+up not working on them. Must fix that.

--- a/example_site/templates/blog/index.html
+++ b/example_site/templates/blog/index.html
@@ -29,7 +29,7 @@
 </div>
 
 <div id="content">
-    {% set content = view(entry_type_not='sidebar',limit=5) %}
+    {% set content = view(entry_type_not='sidebar',limit=10) %}
 
     <div class="nav">
         {% if content.previous %}

--- a/example_site/templates/index.html
+++ b/example_site/templates/index.html
@@ -32,7 +32,7 @@
 </div>
 
 <div id="content">
-    {% set content = view(entry_type_not='sidebar',limit=5) %}
+    {% set content = view(entry_type_not='sidebar',limit=20) %}
 
     <div class="nav">
         {% if content.previous %}

--- a/main.py
+++ b/main.py
@@ -38,7 +38,6 @@ def set_cache_expiry(r):
     r.headers['Cache-Control'] = 'public, max-age=300'
     return r
 
-
 publ.setup(app)
 
 def scan_index():

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -1,6 +1,7 @@
-from . import rendering, model, index
+from . import rendering, model, index, caching
 import arrow
 import flask
+from .caching import cache
 
 model = model
 index = index
@@ -28,3 +29,5 @@ def setup(app):
         app.register_error_handler(Exception, rendering.render_exception)
 
     app.jinja_env.globals.update(get_view=view.get_view, arrow=arrow, static=rendering.static_url)
+
+    cache.init_app(app)

--- a/publ/caching.py
+++ b/publ/caching.py
@@ -2,7 +2,7 @@
 # Where the cache lives
 
 import config
-from flask.ext.cache import Cache
+from flask_cache import Cache
 from flask import request
 
 cache = Cache(config=config.cache)

--- a/publ/caching.py
+++ b/publ/caching.py
@@ -1,0 +1,17 @@
+# caching.py
+# Where the cache lives
+
+import config
+from flask.ext.cache import Cache
+from flask import request
+
+cache = Cache(config=config.cache)
+
+''' Key generator for categories '''
+def make_category_key():
+    return 'category/' + request.full_path
+
+''' Key generator for entries '''
+def make_entry_key():
+    return 'entry/' + request.path
+

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -9,6 +9,8 @@ from .entry import Entry, expire_record
 from .category import Category
 from .template import Template
 from .view import View
+from . import caching
+from .caching import cache
 
 import config
 
@@ -25,6 +27,7 @@ def mimetype(template):
     _,ext = os.path.splitext(template.filename)
     return extmap.get(ext, 'text/html; charset=utf-8')
 
+@cache.memoize()
 def map_template(orig_path, template_list):
     if type(template_list) == str:
         template_list = [template_list]
@@ -82,6 +85,7 @@ def render_path_alias(path):
         return render_error('', 'Path redirection not found', 404)
     return redirect(redir)
 
+@cache.cached(key_prefix=caching.make_category_key)
 def render_category(category='', template='index'):
     # See if this is an aliased path
     redir = get_redirect()
@@ -121,6 +125,7 @@ def render_category(category='', template='index'):
         view=view_obj,
         template=tmpl), { 'Content-Type': mimetype(tmpl) }
 
+@cache.cached(key_prefix=caching.make_entry_key)
 def render_entry(entry_id, slug_text='', category=''):
     # check if it's a valid entry
     record = model.Entry.get_or_none(model.Entry.id == entry_id)

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -22,10 +22,12 @@ extmap = {
     '.json': 'application/json'
 }
 
+
 def mimetype(template):
     # infer the content-type from the extension
-    _,ext = os.path.splitext(template.filename)
+    _, ext = os.path.splitext(template.filename)
     return extmap.get(ext, 'text/html; charset=utf-8')
+
 
 @cache.memoize()
 def map_template(orig_path, template_list):
@@ -46,11 +48,14 @@ def map_template(orig_path, template_list):
             else:
                 path = None
 
+
 def static_url(path, absolute=False):
     return url_for('static', filename=path, _external=absolute)
 
+
 def get_redirect():
     return path_alias.get_redirect([request.full_path, request.path])
+
 
 def render_error(category, error_message, error_codes, exception=None):
     if type(error_codes) == int:
@@ -64,26 +69,29 @@ def render_error(category, error_message, error_codes, exception=None):
     if template:
         return render_template(
             template.filename,
-            error={'code':error_code, 'message':error_message},
+            error={'code': error_code, 'message': error_message},
             exception=exception,
             template=template), error_code
 
     # no template found, so fall back to default Flask handler
     flask.abort(error_code)
 
+
 def render_exception(error):
-    _,_,category = str.partition(request.path, '/')
+    _, _, category = str.partition(request.path, '/')
     return render_error(category, "Exception occurred", 500, exception={
         'type': type(error).__name__,
         'str': str(error),
         'args': error.args
-        })
+    })
+
 
 def render_path_alias(path):
     redir = path_alias.get_redirect('/' + path)
     if not redir:
         return render_error('', 'Path redirection not found', 404)
     return redirect(redir)
+
 
 @cache.cached(key_prefix=caching.make_category_key)
 def render_category(category='', template='index'):
@@ -99,17 +107,17 @@ def render_category(category='', template='index'):
     if category:
         # See if there's any entries for the view...
         if not model.Entry.get_or_none((model.Entry.category == category) |
-            (model.Entry.category.startswith(category + '/'))):
+                                       (model.Entry.category.startswith(category + '/'))):
             return render_error(category, 'Category not found', 404)
 
     tmpl = map_template(category, template)
 
     if not tmpl:
        # this might actually be a malformed category URL
-        test_path = os.path.join(category,template)
+        test_path = os.path.join(category, template)
         record = model.Entry.get_or_none(model.Entry.category == test_path)
         if record:
-            return redirect(url_for('category',category=test_path))
+            return redirect(url_for('category', category=test_path))
 
         # nope, we just don't know what this is
         return render_error(category, 'Template not found', 400)
@@ -121,9 +129,10 @@ def render_category(category='', template='index'):
 
     view_obj = View(view_spec)
     return render_template(tmpl.filename,
-        category=Category(category),
-        view=view_obj,
-        template=tmpl), { 'Content-Type': mimetype(tmpl) }
+                           category=Category(category),
+                           view=view_obj,
+                           template=tmpl), {'Content-Type': mimetype(tmpl)}
+
 
 @cache.cached(key_prefix=caching.make_entry_key)
 def render_entry(entry_id, slug_text='', category=''):
@@ -170,9 +179,9 @@ def render_entry(entry_id, slug_text='', category=''):
 
         # Redirect to the canonical URL
         return redirect(url_for('entry',
-            entry_id=entry_id,
-            category=record.category,
-            slug_text=record.slug_text))
+                                entry_id=entry_id,
+                                category=record.category,
+                                slug_text=record.slug_text))
 
     # if the entry canonically redirects, do that now
     entry_redirect = entry_obj.get('Redirect-To')
@@ -184,7 +193,6 @@ def render_entry(entry_id, slug_text='', category=''):
         return render_error(category, 'Entry template not found', 400)
 
     return render_template(tmpl.filename,
-        entry=entry_obj,
-        category=Category(category),
-        template=tmpl), { 'Content-Type': mimetype(tmpl) }
-
+                           entry=entry_obj,
+                           category=Category(category),
+                           template=tmpl), {'Content-Type': mimetype(tmpl)}


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Enable caching for the most I/O-bound operations

## Detailed description

This adds the use of [Flask-Cache](https://pythonhosted.org/Flask-Cache/) to add some very basic caching; in particular, we now cache:

* Template lookups
* Entry message loads/parses
* Renders of entry and category pages

## Developer/user impact

There now needs to be a caching configuration added to `config.py`. See `config.py.dist` for some reasonable defaults.

## Test plan

* Ensure that different pages on category views look different
* If content changes, the view shouldn't change until the cache TTL expires
