### PR TITLE
Fix the timezone for the query span

### DIFF
--- a/publ/queries.py
+++ b/publ/queries.py
@@ -118,8 +118,10 @@ def where_entry_date(datespec):
     date, interval, _ = utils.parse_date(datespec)
     start_date, end_date = date.span(interval)
 
-    return ((model.Entry.entry_date >= start_date.datetime) &
-            (model.Entry.entry_date <= end_date.datetime))
+    print('where_entry_date', start_date, end_date)
+
+    return ((model.Entry.entry_date >= start_date.to('utc').datetime) &
+            (model.Entry.entry_date <= end_date.to('utc').datetime))
 
 
 def get_entry(entry):

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -70,7 +70,7 @@ def parse_date(datestr):
 
     match = re.match(r'([0-9]{4})(-?([0-9]{1,2}))?(-?([0-9]{1,2}))?$', datestr)
     if not match:
-        return (arrow.get(datestr), 'day', 'YYYY-MM-DD')
+        return (arrow.get(datestr, tzinfo=config.timezone).replace(tzinfo=config.timezone), 'day', 'YYYY-MM-DD')
 
     year, month, day = match.group(1, 3, 5)
     start = arrow.Arrow(year=int(year), month=int(


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes issue #48 by normalizing the time zone on the query range

## Detailed description

So it turns out the "unnecessary" split for entry date vs. display date ended up being very useful, because that made fixing this bug very easy. Turns out SQLite doesn't do timezone-aware queries after all! So even though that work was done unnecessarily to fix an unrelated bug it still ended up being useful in the long run.

This should also 

## Test plan

Tested the blog view with `/blog/?date=2018-04-17` and ensured that pagination works correctly.

