### PR TITLE
Add entry archive links

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ pylint:
 build:
 	rm -rf build dist
 	python3 setup.py sdist
-	python3 setup.py bdist_wheel --universal
+	python3 setup.py bdist_wheel
 
 .PHONY: upload
 upload: build

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -130,6 +130,7 @@ class Entry:
                 "relative_search_path": self._relative_search_path,
                 "absolute_search_path": self._absolute_search_path
             }
+
             return flask.Markup(markdown.to_html(text, config=md_config))
         return flask.Markup(text)
 

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -51,10 +51,10 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
         container_args = {**self._config, **container_args}
 
-        if 'limit' in container_args:
-            if 'limit_offset' in container_args:
-                spec_list = spec_list[container_args['limit_offset']:]
-            spec_list = spec_list[:container_args['limit']]
+        if 'count' in container_args:
+            if 'count_offset' in container_args:
+                spec_list = spec_list[container_args['count_offset']:]
+            spec_list = spec_list[:container_args['count']]
 
         if 'div_class' in container_args:
             text += self._make_tag('div',

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -43,10 +43,14 @@ class CallableProxy:
             self._has_default = True
         return self._default
 
-    def __call__(self, **kwargs):
+    def __call__(self, *args, **kwargs):
         # use the new kwargs to override the defaults
         kwargs = dict(self._default_kwargs, **kwargs)
-        return self._func(*self._default_args, **kwargs)
+
+        # override args as well
+        pos_args = [*args, *self._default_args[len(args):]]
+
+        return self._func(*pos_args, **kwargs)
 
     def __getattr__(self, name):
         return getattr(self._get_default(), name)
@@ -74,6 +78,15 @@ class TrueCallableProxy(CallableProxy):
     def __len__(self):
         return True
 
+#: arrow format string for 'day' archives
+DAY_FORMAT = 'YYYY-MM-DD'
+
+#: arrow format string for 'month' archives
+MONTH_FORMAT = 'YYYY-MM'
+
+#: arrow format string for 'year' archives
+YEAR_FORMAT = 'YYYY'
+
 
 def parse_date(datestr):
     """ Parse a date expression into a tuple of:
@@ -95,11 +108,11 @@ def parse_date(datestr):
         month or 1), day=int(day or 1), tzinfo=config.timezone)
 
     if day:
-        return start, 'day', 'YYYY-MM-DD'
+        return start, 'day', DAY_FORMAT
     elif month:
-        return start, 'month', 'YYYY-MM'
+        return start, 'month', MONTH_FORMAT
     elif year:
-        return start, 'year', 'YYYY'
+        return start, 'year', YEAR_FORMAT
 
     raise ValueError("Could not parse date: {}".format(datestr))
 

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with open(path.join(here, 'README.md')) as f:
 setup(
     name='Publ',
 
-    version='0.1.2',
+    version='0.1.3',
 
     description='A content-management system for flexible web-based publishing',
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Adds `entry.archive` to the templates, and also changes `limit` parameters to `count`

## Detailed description

Now you can get the "archive link" for an entry with e.g.

    {{entry.archive(paging='day',template=template.name,category=category.path)}}

This also finally fixes `CallableProxy` to allow variable positional argument lists, and as such the above can also be written:

    {{entry.archive('day',template.name,category.path)}}

The docs will be updated over on publ.beesbuzz.biz.

## Developer/user impact

All templates that use a `limit` parameter (on a view or an entry text configuration) need to be changed to `count` instead.

