### PR TITLE
Remove the last few remaining spurious __getattr__s

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -55,8 +55,8 @@ class Category:
     @cached_property
     def parent(self):
         """ Get the parent category """
-        if path:
-            return Category(os.path.dirname(path))
+        if self.path:
+            return Category(os.path.dirname(self.path))
         return None
 
     def _get_subcats(self, recurse=False):

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -15,6 +15,7 @@ import uuid
 
 import arrow
 import flask
+from werkzeug.utils import cached_property
 
 from . import config
 from . import model
@@ -148,17 +149,7 @@ class Entry:
         return flask.Markup(text)
 
     def __getattr__(self, name):
-        """ Lazy binding for deferred properties """
-        # pylint: disable=attribute-defined-outside-init
-        if name == 'previous':
-            # Get the previous entry in the same category (by date)
-            self.previous = self.previous_in(self._record.category, False)
-            return self.previous
-
-        if name == 'next':
-            # Get the next entry in the same category (by date)
-            self.next = self.next_in(self._record.category, False)
-            return self.next
+        """ Proxy undefined properties to the backing objects """
 
         if hasattr(self._record, name):
             return getattr(self._record, name)

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -91,7 +91,7 @@ class Entry:
 
         return flask.url_for('category', **args, _external=absolute)
 
-    @property
+    @cached_property
     def image_search_path(self):
         """ The relative image search path for this entry """
         return [


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #51 

## Detailed description

Turns out most of them were in `view.py` already; there were a couple in `entry.py` which were just dead code anyway, and there was one trivial one in `category.py`.

