### PR TITLE
Add OpenGraph card support

### DIFF
--- a/publ/cards.py
+++ b/publ/cards.py
@@ -1,0 +1,96 @@
+# cards.py
+""" Rendering functions for Twitter/OpenGraph cards"""
+
+import misaka
+import flask
+
+from . import image, utils
+
+
+class CardData():
+    """ Extracted card data """
+
+    def __init__(self):
+        self.description = None
+        self.image = None
+
+
+class CardParser(misaka.BaseRenderer):
+    """ Customized Markdown renderer for parsing out information for a card """
+
+    def __init__(self, out, config, image_search_path):
+        super().__init__()
+
+        self._config = {**config, 'absolute': True}
+        self._image_search_path = image_search_path
+
+        self._out = out
+
+    def paragraph(self, content):
+        """ Turn the first paragraph of text into the summary text """
+        if not self._out.description:
+            self._out.description = content.strip()
+        return ' '
+
+    def image(self, raw_url, title='', alt=''):
+        """ Extract the first image """
+        if self._out.image:
+            # We already have an image, so we can abort
+            return ' '
+
+        image_specs = raw_url
+        if title:
+            image_specs += ' "{}"'.format(title)
+
+        alt, container_args = image.parse_alt_text(alt)
+
+        spec_list = [spec.strip() for spec in image_specs.split('|')]
+
+        if 'count' in container_args:
+            if 'count_offset' in container_args:
+                spec_list = spec_list[container_args['count_offset']:]
+            spec_list = spec_list[:container_args['count']]
+
+        for spec in spec_list:
+            if not spec:
+                continue
+
+            self._out.image = self._render_image(spec, alt)
+            if self._out.image:
+                break
+
+        return ' '
+
+    def link(self, content, link, title=''):
+        return content
+
+    def _render_image(self, spec, alt):
+        """ Given an image spec, try to turn it into a card image per the configuration """
+        try:
+            path, image_args, title = image.parse_image_spec(spec)
+        except Excpetion as err:  # pylint: disable=broad-except
+            # we tried™
+            return None
+
+        if path.startswith('@'):
+            # static image resource
+            return utils.static_url(path[1:], absolute=True)
+
+        if path.startswith('//') or '://' in path:
+            # remote image
+            return path
+
+        img = image.get_image(path, self._image_search_path)
+        if img:
+            return utils.static_url(img.get_rendition(1, self._config)[0], absolute=True)
+
+        return None
+
+
+def extract_card(text, config, image_search_path):
+    """ Extract card data based on the provided texts. """
+    card = CardData()
+    parser = CardParser(card, config, image_search_path)
+    misaka.Markdown(parser)(text)
+
+    return card

--- a/publ/cards.py
+++ b/publ/cards.py
@@ -16,7 +16,7 @@ class CardData():
 
     def __init__(self):
         self.description = None
-        self.image = None
+        self.images = []
 
 
 class CardParser(misaka.BaseRenderer):
@@ -38,9 +38,10 @@ class CardParser(misaka.BaseRenderer):
         return ' '
 
     def image(self, raw_url, title='', alt=''):
-        """ Extract the first image """
-        if self._out.image:
-            # We already have an image, so we can abort
+        ''' extract the images '''
+        max_images = self._config.get('count')
+        if max_images is not None and len(self._out.images) >= max_images:
+            # We already have enough images, so bail out
             return ' '
 
         image_specs = raw_url
@@ -55,8 +56,8 @@ class CardParser(misaka.BaseRenderer):
             if not spec:
                 continue
 
-            self._out.image = self._render_image(spec, alt)
-            if self._out.image:
+            self._out.images.append(self._render_image(spec, alt))
+            if max_images is not None and len(self._out.images) >= max_images:
                 break
 
         return ' '

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -157,6 +157,7 @@ class Entry:
         """ Render out the tags for a Twitter/OpenGraph card for this entry. """
 
         def og_tag(key, val):
+            """ produce an OpenGraph tag with the given key and value """
             return utils.make_tag('meta', {'property': key, 'content': val}, start_end=True)
 
         tags = og_tag('og:title', self.title)

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -164,8 +164,8 @@ class Entry:
         tags += og_tag('og:url', self.link(absolute=True))
 
         card = cards.extract_card(text, kwargs, self.image_search_path)
-        if card.image:
-            tags += og_tag('og:image', card.image)
+        for image in card.images:
+            tags += og_tag('og:image', image)
         if card.description:
             tags += og_tag('og:description', card.description)
 

--- a/publ/image.py
+++ b/publ/image.py
@@ -7,6 +7,9 @@ import os
 import hashlib
 import logging
 
+import re
+import ast
+
 import PIL.Image
 
 from . import config
@@ -334,3 +337,62 @@ def get_image(path, search_path):
             record.update(**values).where(model.Image.id == record.id)
 
     return Image(record)
+
+
+def parse_arglist(args):
+    """ Parses an arglist into arguments for Image, as a kwargs dict """
+    # per https://stackoverflow.com/a/49723227/318857
+
+    args = 'f({})'.format(args)
+    tree = ast.parse(args)
+    funccall = tree.body[0].value
+
+    args = [ast.literal_eval(arg) for arg in funccall.args]
+    kwargs = {arg.arg: ast.literal_eval(arg.value)
+              for arg in funccall.keywords}
+
+    if len(args) > 2:
+        raise TypeError(
+            "Expected at most 2 positional args but {} were given".format(len(args)))
+
+    if len(args) >= 1:
+        kwargs['width'] = int(args[0])
+    if len(args) >= 2:
+        kwargs['height'] = int(args[1])
+
+    return kwargs
+
+
+def parse_alt_text(alt):
+    """ Parses the arguments out from a Publ-Markdown alt text into a tuple of text, args """
+    match = re.match(r'([^\{]*)(\{(.*)\})$', alt)
+    if match:
+        alt = match.group(1)
+        args = parse_arglist(match.group(3))
+    else:
+        args = {}
+
+    return alt, args
+
+
+def parse_image_spec(spec):
+    """ Parses out a Publ-Markdown image spec into a tuple of path, args, title """
+
+    # I was having trouble coming up with a single RE that did it right,
+    # so let's just break it down into sub-problems. First, parse out the
+    # alt text...
+    match = re.match(r'(.+)\s+\"(.*)\"\s*$', spec)
+    if match:
+        spec, title = match.group(1, 2)
+    else:
+        title = None
+
+    # and now parse out the arglist
+    match = re.match(r'([^\{]*)(\{(.*)\})\s*$', spec)
+    if match:
+        spec = match.group(1)
+        args = parse_arglist(match.group(3))
+    else:
+        args = {}
+
+    return spec, args, title

--- a/publ/image.py
+++ b/publ/image.py
@@ -396,3 +396,17 @@ def parse_image_spec(spec):
         args = {}
 
     return spec, args, title
+
+
+def get_spec_list(image_specs, container_args):
+    """ Given a list of specs and a set of container args, return the final
+    container argument list """
+
+    spec_list = [spec.strip() for spec in image_specs.split('|')]
+
+    if 'count' in container_args:
+        if 'count_offset' in container_args:
+            spec_list = spec_list[container_args['count_offset']:]
+        spec_list = spec_list[:container_args['count']]
+
+    return spec_list

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -47,14 +47,9 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
         alt, container_args = image.parse_alt_text(alt)
 
-        spec_list = [spec.strip() for spec in image_specs.split('|')]
-
         container_args = {**self._config, **container_args}
 
-        if 'count' in container_args:
-            if 'count_offset' in container_args:
-                spec_list = spec_list[container_args['count_offset']:]
-            spec_list = spec_list[:container_args['count']]
+        spec_list = image.get_spec_list(image_specs, container_args)
 
         for spec in spec_list:
             if not spec:
@@ -206,7 +201,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
         return text
 
-    def _fullsize_link(self, img, image_args, title, absolute):
+    @staticmethod
+    def _fullsize_link(img, image_args, title, absolute):
         fullsize_args = {}
         for key in ['width', 'height', 'quality', 'format', 'background']:
             fsk = 'fullsize_' + key
@@ -222,7 +218,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
             'title': title
         })
 
-    def _remote_image(self, path, image_args, title, alt_text):
+    @staticmethod
+    def _remote_image(path, image_args, title, alt_text):
         """ Render an img tag for a remotely-stored image """
 
         attrs = {

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -154,3 +154,23 @@ def static_url(path, absolute=False):
     absolute -- whether the link should be absolute or relative
     """
     return flask.url_for('static', filename=path, _external=absolute)
+
+
+def make_tag(name, attrs, start_end=False):
+    """ Build an HTML tag from the given name and attributes.
+
+    Arguments:
+
+    name -- the name of the tag (p, div, etc.)
+    attrs -- a dict of attributes to apply to the tag
+    start_end -- whether this tag should be self-closing
+    """
+
+    text = '<' + name
+    for key, val in attrs.items():
+        if val is not None:
+            text += ' {}="{}"'.format(key, flask.escape(val))
+    if start_end:
+        text += ' /'
+    text += '>'
+    return text


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Add the `entry.card` primitive for generating OpenGraph metadata, as a solution for #45 

## Detailed description

Now we can make cards for Twitter et al. Yay.

## Test plan

Verified working with publ.beesbuzz.biz content

## Got a site to show off?

<!-- If so, link to it here! -->
