### PR TITLE
Fix entry pagination

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -52,6 +52,15 @@ class Category:
     def __str__(self):
         return self.path
 
+    def __eq__(self, other):
+        return other.path == self.path
+
+    def __hash__(self):
+        return hash(self.path)
+
+    def __lt__(self, other):
+        return self.path < other.path
+
     @cached_property
     def parent(self):
         """ Get the parent category """
@@ -93,12 +102,10 @@ class Category:
 
     def _first(self, **spec):
         """ Get the earliest entry in this category, optionally including subcategories """
-        first = self._entries(spec).order_by(
-            model.Entry.entry_date, model.Entry.id)
-        return entry.Entry(first[0]) if first else None
+        return entry.Entry(self._entries(spec).order_by(
+            model.Entry.entry_date, model.Entry.id).get())
 
     def _last(self, **spec):
         """ Get the latest entry in this category, optionally including subcategories """
-        last = self._entries(spec).order_by(
-            -model.Entry.entry_date, -model.Entry.id)
-        return entry.Entry(last[0]) if last else None
+        return entry.Entry(self._entries(spec).order_by(
+            -model.Entry.entry_date, -model.Entry.id).get())

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -61,7 +61,7 @@ class Entry:
         self.next = CallableProxy(self._next)
         self.previous = CallableProxy(self._previous)
 
-        from .category import Category
+        from .category import Category  # pylint: disable=cyclic-import
         self.category = Category(record.category)
 
     def _link(self, *args, **kwargs):
@@ -91,7 +91,7 @@ class Entry:
         elif paging == 'year':
             args['date'] = self.date.format(utils.YEAR_FORMAT)
         else:
-            args['first'] = self._record.id
+            args['start'] = self._record.id
 
         return flask.url_for('category', **args, _external=absolute)
 
@@ -196,7 +196,7 @@ class Entry:
     def _previous(self, **kwargs):
         # Get the previous item in any particular category
         spec = {
-            'category': self._record.category,
+            'category': kwargs.get('category', self._record.category),
             'recurse': 'category' in kwargs
         }
         spec.update(kwargs)
@@ -209,7 +209,7 @@ class Entry:
     def _next(self, **kwargs):
         # Get the next item in any particular category
         spec = {
-            'category': self._record.category,
+            'category': kwargs.get('category', self._record.category),
             'recurse': 'category' in kwargs
         }
         spec.update(kwargs)

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -193,12 +193,16 @@ class Entry:
         query = query.limit(1)
         return Entry(query[0]) if query.count() else None
 
-    def _previous(self, **kwargs):
-        # Get the previous item in any particular category
-        spec = {
-            'category': kwargs.get('category', self._record.category),
-            'recurse': 'category' in kwargs
+    def _pagination_default_spec(self, kwargs):
+        category = kwargs.get('category', self._record.category)
+        return {
+            'category': category,
+            'recurse': kwargs.get('recurse', category != self._record.category)
         }
+
+    def _previous(self, **kwargs):
+        """ Get the previous item in any particular category """
+        spec = self._pagination_default_spec(kwargs)
         spec.update(kwargs)
 
         return self._get_first(model.Entry.select().where(
@@ -207,11 +211,8 @@ class Entry:
         ).order_by(-model.Entry.entry_date, -model.Entry.id))
 
     def _next(self, **kwargs):
-        # Get the next item in any particular category
-        spec = {
-            'category': kwargs.get('category', self._record.category),
-            'recurse': 'category' in kwargs
-        }
+        """ Get the next item in any particular category """
+        spec = self._pagination_default_spec(kwargs)
         spec.update(kwargs)
 
         return self._get_first(

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -208,7 +208,7 @@ def render_category(category='', template='index'):
         return render_error(category, 'Template not found', 400)
 
     view_spec = {'category': category}
-    for key in ['date', 'last', 'first', 'before', 'after']:
+    for key in ['date', 'start', 'last', 'first', 'before', 'after']:
         if key in request.args:
             view_spec[key] = request.args[key]
 

--- a/publ/view.py
+++ b/publ/view.py
@@ -209,8 +209,17 @@ class View:
         base = {key: val for key, val in self.spec.items()
                 if key not in OFFSET_PRIORITY}
 
-        oldest_neighbor = View({**base, 'before': oldest, 'order': 'newest'}).first if oldest else None
-        newest_neighbor = View({**base, 'after': newest, 'order': 'oldest'}).first if newest else None
+        oldest_neighbor = View({
+            **base,
+            'before': oldest,
+            'order': 'newest'
+        }).first if oldest else None
+
+        newest_neighbor = View({
+            **base,
+            'after': newest,
+            'order': 'oldest'
+        }).first if newest else None
 
         if 'date' in self.spec:
             print('date pagination', oldest_neighbor, newest_neighbor)
@@ -246,26 +255,32 @@ class View:
 
         count = self.spec['count']
 
-        newer_count = View({**base,
-                            'first': newest_neighbor,
-                            'order': 'oldest',
-                            'count': count}) if newest_neighbor else None
-
-        older_count = View({**base,
-                            'last': oldest_neighbor,
-                            'order': 'newest',
-                            'count': count}) if oldest_neighbor else None
-
         out_spec = {**base, 'count': count, 'order': self._order_by}
 
         if self._order_by == 'newest':
-            older_view = View({**out_spec, 'last': oldest_neighbor}) if oldest_neighbor else None
-            newer_view = View({**out_spec, 'last': newer_count.last}) if newer_count else None
+            older_view = View({**out_spec,
+                               'last': oldest_neighbor}) if oldest_neighbor else None
+
+            newer_count = View({**base,
+                                'first': newest_neighbor,
+                                'order': 'oldest',
+                                'count': count}) if newest_neighbor else None
+            newer_view = View({**out_spec,
+                               'last': newer_count.last}) if newer_count else None
+
             return older_view, newer_view
 
         if self._order_by == 'oldest':
-            older_view = View({**out_spec, 'first': older_count.last}) if older_count else None
-            newer_view = View({**out_spec, 'first': newest_neighbor}) if newest_neighbor else None
+            older_count = View({**base,
+                                'last': oldest_neighbor,
+                                'order': 'newest',
+                                'count': count}) if oldest_neighbor else None
+            older_view = View({**out_spec,
+                               'first': older_count.last}) if older_count else None
+
+            newer_view = View({**out_spec,
+                               'first': newest_neighbor}) if newest_neighbor else None
+
             return older_view, newer_view
 
         return None, None
@@ -309,7 +324,9 @@ class View:
             template = formats.get(
                 'single', '{oldest} — {newest} ({count})')
 
-        return template.format(count=len(self.entries), oldest=oldest, newest=newest)
+        return template.format(count=len(self.entries),
+                               oldest=oldest,
+                               newest=newest)
 
 
 def get_view(**kwargs):

--- a/publ/view.py
+++ b/publ/view.py
@@ -77,8 +77,6 @@ class View:
             elif self._order_by == 'newest':
                 self.spec['last'] = self.spec['start']
 
-        print('spec', spec)
-
         self._where = queries.build_query(spec)
         self._query = model.Entry.select().where(self._where)
 
@@ -222,11 +220,9 @@ class View:
         }).first if newest else None
 
         if 'date' in self.spec:
-            print('date pagination', oldest_neighbor, newest_neighbor)
             return self._get_date_pagination(base, oldest_neighbor, newest_neighbor)
 
         if 'count' in self.spec:
-            print('count pagination', oldest_neighbor, newest_neighbor)
             return self._get_count_pagination(base, oldest_neighbor, newest_neighbor)
 
         # we're not paginating
@@ -319,10 +315,10 @@ class View:
         newest = self.newest.date.format(date_format)
 
         if oldest == newest:
-            template = formats.get('span', '{oldest} ({count})')
+            template = formats.get('single', '{oldest} ({count})')
         else:
             template = formats.get(
-                'single', '{oldest} — {newest} ({count})')
+                'span', '{oldest} — {newest} ({count})')
 
         return template.format(count=len(self.entries),
                                oldest=oldest,


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Rewrite the pagination system to make it actually work more or less correctly

## Detailed description

The code was overly-complicated and full of design debt. Now that I have a better idea of what I'm doing, this fixes #73 and pagination works correctly across recursive views as well as with both newest and oldest sort orders.

This also adds another view constraint, `start`, which tells the view to start at the specified entry regardless of sort order. This allows an entry's archive link to work even without knowing what sort order the resulting view will have.

Testing this unearthed issue #72 which is related to pagination but not a problem with the actual pagination code.

## Test plan

Tested as part of beesbuzz.biz site migration, with its ridiculously complicated recursive categories
