### PR TITLE
Feature/76 image refactor

### DIFF
--- a/publ/cards.py
+++ b/publ/cards.py
@@ -89,8 +89,8 @@ class CardParser(misaka.BaseRenderer):
 
         img = image.get_image(path, self._image_search_path)
         if img:
-            image_config = {**image_args, **self._config}
-            return utils.static_url(img.get_rendition(1, image_config)[0], absolute=True)
+            image_config = {**image_args, **self._config, 'absolute': True}
+            return img.get_rendition(1, **image_config)[0]
 
         return None
 

--- a/publ/category.py
+++ b/publ/category.py
@@ -10,7 +10,7 @@ from werkzeug.utils import cached_property
 
 from . import model
 from . import utils
-from . import entry
+from . import entry  # pylint: disable=cyclic-import
 from . import queries
 
 

--- a/publ/image.py
+++ b/publ/image.py
@@ -349,7 +349,7 @@ class LocalImage(Image):
 
         return text
 
-    def _fullsize_link_tag(kwargs, title):
+    def _fullsize_link_tag(self, kwargs, title):
         """ Render a <a href> that points to the fullsize rendition specified """
         fullsize_args = {}
 
@@ -361,7 +361,7 @@ class LocalImage(Image):
             if fsk in kwargs:
                 fullsize_args[key] = kwargs[fsk]
 
-        img_fullsize, _ = img.get_rendition(1, fullsize_args)
+        img_fullsize, _ = self.get_rendition(1, fullsize_args)
 
         return utils.make_tag('a', {
             'href': img_fullsize,
@@ -401,7 +401,7 @@ class RemoteImage(Image):
 
         if width and height and size_mode != 'stretch':
             attrs['style'] = ';'.join([
-                'background-image:url(\'{}\')'.format(flask.escape(self.url)),
+                'background-image:url(\'{}\')'.format(html.escape(self.url)),
                 'background-size:{}'.format(self.CSS_SIZE_MODE[size_mode]),
                 'background-position:{:.1f}% {:.1f}%'.format(
                     kwargs.get('fill_crop_x', 0.5) * 100,
@@ -420,12 +420,13 @@ class RemoteImage(Image):
         text = utils.make_tag('img', attrs)
 
         if 'link' in kwargs and kwargs['link'] is not None:
-            text = '<a href="{}">{}</a>'.format(
-                flask.escape(kwargs['link']), text)
+            text = '{}{}</a>'.format(
+                utils.make_link('a', {'href': kwargs['link']}),
+                text)
         elif 'gallery_id' in kwargs and kwargs['gallery_id'] is not None:
             text = '{}{}</a>'.format(
                 utils.make_tag('a', {
-                    'href': path,
+                    'href': self.url,
                     'data-lightbox': kwargs['gallery_id'],
                     'title': title
                 }),

--- a/publ/image.py
+++ b/publ/image.py
@@ -463,7 +463,12 @@ class ImageNotFound(Image):
 
     def get_img_tag(self, title='', alt_text='', **kwargs):
         # pylint:disable=unused-argument
-        return '<span class="error">Image not found: {}</span>'.format(self.path)
+        text = '<span class="error">Image not found: <code>{}</code>'.format(
+            html.escape(self.path))
+        if ' ' in self.path:
+            text += ' (Did you forget a <code>|</code>?)'
+        text += '</span>'
+        return text
 
 
 def get_image(path, search_path):

--- a/publ/image.py
+++ b/publ/image.py
@@ -140,7 +140,7 @@ class LocalImage(Image):
                 image = self.flatten(image, kwargs.get('background'))
             image.save(out_fullpath, **out_args)
 
-        return out_rel_path, size
+        return utils.static_url(out_rel_path, kwargs.get('absolute')), size
 
     def get_rendition_size(self, spec, output_scale):
         """
@@ -323,6 +323,9 @@ class LocalImage(Image):
         return image.convert('RGB')
 
     def get_img_tag(self, title='', alt_text='', **kwargs):
+
+        print("get_img_tag", kwargs)
+
         # Get the 1x and 2x renditions
         img_1x, size = self.get_rendition(
             1, **utils.remap_args(kwargs, {"quality": "quality_ldpi"}))
@@ -340,8 +343,9 @@ class LocalImage(Image):
 
         # Wrap it in a link as appropriate
         if 'link' in kwargs and kwargs['link'] is not None:
+            print('adding link ' + str(kwargs['link']))
             text = '{}{}</a>'.format(
-                utils.make_tag('a', {'link': kwargs['link']}),
+                utils.make_tag('a', {'href': kwargs['link']}),
                 text)
         elif 'gallery_id' in kwargs and kwargs['gallery_id'] is not None:
             text = '{}{}</a>'.format(
@@ -361,7 +365,7 @@ class LocalImage(Image):
             if fsk in kwargs:
                 fullsize_args[key] = kwargs[fsk]
 
-        img_fullsize, _ = self.get_rendition(1, fullsize_args)
+        img_fullsize, _ = self.get_rendition(1, **fullsize_args)
 
         return utils.make_tag('a', {
             'href': img_fullsize,

--- a/publ/image.py
+++ b/publ/image.py
@@ -104,6 +104,10 @@ class Image:
 
             image = PIL.Image.open(input_filename)
 
+            paletted = image.mode == 'P'
+            if paletted:
+                image.convert('RGB')
+
             if size:
                 image = image.resize(size=size, box=box,
                                      resample=PIL.Image.LANCZOS)

--- a/publ/image.py
+++ b/publ/image.py
@@ -22,7 +22,7 @@ logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 class Image:
     """ Base class for image handlers """
 
-    def get_rendition(self, output_scale, **kwargs):
+    def get_rendition(self, output_scale=1, **kwargs):
         """ Get a rendition of the image with the specified output scale and specification.
 
         Returns: a tuple of (url, size) for the image. """
@@ -34,8 +34,8 @@ class Image:
         Returns: an HTML fragment. """
         pass
 
-    def __call__(self, output_scale=1, **kwargs):
-        url, _ = self.get_rendition(output_scale, **kwargs)
+    def __call__(self, *args, **kwargs):
+        url, _ = self.get_rendition(*args, **kwargs)
         return url
 
     def __str__(self):
@@ -51,7 +51,7 @@ class LocalImage(Image):
         super().__init__()
         self._record = record
 
-    def get_rendition(self, output_scale, **kwargs):
+    def get_rendition(self, output_scale=1, **kwargs):
         """
         Get the rendition for this image, generating it if necessary.
         Returns a tuple of `(relative_path, width, height)`, where relative_path
@@ -383,7 +383,7 @@ class RemoteImage(Image):
         super().__init__()
         self.url = url
 
-    def get_rendition(self, output_scale, **kwargs):
+    def get_rendition(self, output_scale=1, **kwargs):
         # pylint: disable=unused-argument
         return self.url
 
@@ -441,7 +441,7 @@ class StaticImage(Image):
         super().__init__()
         self.path = path
 
-    def get_rendition(self, output_scale, **kwargs):
+    def get_rendition(self, output_scale=1, **kwargs):
         url = utils.static_url(self.path, absolute=kwargs.get('absolute'))
         return RemoteImage(url).get_rendition(output_scale, **kwargs), None
 

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -42,7 +42,6 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
         alt, container_args = image.parse_alt_text(alt)
 
-        print('image config', self._config, container_args)
         container_args = {**self._config, **container_args}
 
         spec_list = image.get_spec_list(image_specs, container_args)
@@ -51,7 +50,6 @@ class HtmlRenderer(misaka.HtmlRenderer):
             if not spec:
                 continue
 
-            print(spec, container_args)
             text += self._render_image(spec,
                                        container_args,
                                        alt)
@@ -131,8 +129,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
         try:
             img = image.get_image(path, self._image_search_path)
-            return img.get_img_tag(**composite_args)
-        except Exception as err:  # pulint: disable=broad-except
+            return img.get_img_tag(title, alt_text, **composite_args)
+        except Exception as err:  # pylint: disable=broad-except
             logger.exception("Got error on image %s: %s", path, err)
             return ('<span class="error">Error loading image {}: {}</span>'.format(
                 flask.escape(spec), flask.escape(str(err))))
@@ -140,9 +138,6 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
 def to_html(text, config, image_search_path):
     """ Convert Markdown text to HTML """
-
-    print('to_html', config, image_search_path)
-
     processor = misaka.Markdown(HtmlRenderer(config, image_search_path),
                                 extensions=ENABLED_EXTENSIONS)
     return processor(text)

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -42,7 +42,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
         alt, container_args = image.parse_alt_text(alt)
 
-        print('config', self._config, container_args)
+        print('image config', self._config, container_args)
         container_args = {**self._config, **container_args}
 
         spec_list = image.get_spec_list(image_specs, container_args)
@@ -140,6 +140,8 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
 def to_html(text, config, image_search_path):
     """ Convert Markdown text to HTML """
+
+    print('to_html', config, image_search_path)
 
     processor = misaka.Markdown(HtmlRenderer(config, image_search_path),
                                 extensions=ENABLED_EXTENSIONS)

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -42,6 +42,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
         alt, container_args = image.parse_alt_text(alt)
 
+        print('config', self._config, container_args)
         container_args = {**self._config, **container_args}
 
         spec_list = image.get_spec_list(image_specs, container_args)
@@ -50,6 +51,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
             if not spec:
                 continue
 
+            print(spec, container_args)
             text += self._render_image(spec,
                                        container_args,
                                        alt)
@@ -129,7 +131,7 @@ class HtmlRenderer(misaka.HtmlRenderer):
 
         try:
             img = image.get_image(path, self._image_search_path)
-            return img.get_img_tag(composite_args)
+            return img.get_img_tag(**composite_args)
         except Exception as err:  # pulint: disable=broad-except
             logger.exception("Got error on image %s: %s", path, err)
             return ('<span class="error">Error loading image {}: {}</span>'.format(

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -92,13 +92,7 @@ def image_function(template=None, entry=None, category=None):
             os.path.dirname(os.path.relpath(template.filename,
                                             config.template_folder))))
 
-    def rendition(filename, output_scale=1, **kwargs):
-        """ Get a URL for a rendition of an image, to be used by the templates """
-        img = image.get_image(filename, path)
-        return utils.static_url(img.get_rendition(output_scale, kwargs)[0],
-                                absolute=kwargs.get('absolute'))
-
-    return rendition
+    return lambda filename: image.get_image(filename, path)
 
 
 def render_publ_template(template, **kwargs):

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -14,7 +14,6 @@ from . import config
 from . import path_alias
 from . import model
 from . import image
-from . import utils
 from .entry import Entry, expire_record
 from .category import Category
 from .template import Template
@@ -214,7 +213,7 @@ def render_category(category='', template='index'):
 
 
 @cache.cached(key_prefix=caching.make_entry_key)
-def render_entry(entry_id, slug_text='', category=''):  # pylint: disable=too-many-return-statements
+def render_entry(entry_id, slug_text='', category=''):
     """ Render an entry page.
 
     Arguments:
@@ -223,6 +222,8 @@ def render_entry(entry_id, slug_text='', category=''):  # pylint: disable=too-ma
     slug_text -- The expected URL slug text
     category -- The expected category
     """
+
+    # pylint: disable=too-many-return-statements
 
     # check if it's a valid entry
     record = model.Entry.get_or_none(model.Entry.id == entry_id)

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, with_statement
 
 import re
 import os
+import html
 
 import arrow
 import flask
@@ -166,7 +167,7 @@ def make_tag(name, attrs, start_end=False):
     text = '<' + name
     for key, val in attrs.items():
         if val is not None:
-            text += ' {}="{}"'.format(key, flask.escape(val))
+            text += ' {}="{}"'.format(key, html.escape(val))
     if start_end:
         text += ' /'
     text += '>'
@@ -177,3 +178,26 @@ def file_fingerprint(fullpath):
     """ Get a metadata fingerprint for a file """
     stat = os.stat(fullpath)
     return ','.join([str(value) for value in [stat.st_ino, stat.st_mtime, stat.st_size] if value])
+
+
+def remap_args(input_args, remap):
+    """ Generate a new argument list by remapping keys. The 'remap'
+    dict maps from destination key -> priority list of source keys
+    """
+    out_args = input_args
+    for dest_key, src_keys in remap.items():
+        remap_value = None
+        if isinstance(src_keys, str):
+            src_keys = [src_keys]
+
+        for key in src_keys:
+            if key in input_args:
+                remap_value = input_args[key]
+                break
+
+        if remap_value is not None:
+            if out_args is input_args:
+                out_args = {**input_args}
+            out_args[dest_key] = remap_value
+
+    return out_args

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, with_statement
 import re
 import os
 import html
+import urllib.parse
 
 import arrow
 import flask
@@ -201,3 +202,16 @@ def remap_args(input_args, remap):
             out_args[dest_key] = remap_value
 
     return out_args
+
+
+def remap_link_target(path, absolute=False):
+    """ remap a link target to a static URL if it's prefixed with @ """
+    if path.startswith('@'):
+        # static resource
+        return static_url(path[1:], absolute=absolute)
+
+    if absolute:
+        # absolute-ify whatever the URL is
+        return urllib.parse.urljoin(flask.request.url, path)
+
+    return path

--- a/publ/utils.py
+++ b/publ/utils.py
@@ -167,7 +167,7 @@ def make_tag(name, attrs, start_end=False):
     text = '<' + name
     for key, val in attrs.items():
         if val is not None:
-            text += ' {}="{}"'.format(key, html.escape(val))
+            text += ' {}="{}"'.format(key, html.escape(str(val)))
     if start_end:
         text += ' /'
     text += '>'

--- a/publ/view.py
+++ b/publ/view.py
@@ -157,14 +157,14 @@ class View:
     @cached_property
     def older(self):
         """ Gets the older-direction page """
-        if self.order_by == 'oldest':
+        if self._order_by == 'oldest':
             return self.previous
         return self.next
 
     @cached_property
     def newer(self):
         """ Gets the newer-direction page """
-        if self.order_by == 'oldest':
+        if self._order_by == 'oldest':
             return self.next
         return self.previous
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Refactor/genericize image handling; fixes #76 

## Detailed description

Image rendition management is now centralized, rather than baked into the Markdown processor, and now templates have full access to images' `<img>` tag generator, among other things.

## Developer/user impact

Any templates which use `image()` need to be updated.

## Test plan

Thoroughly tested with publ.beesbuzz.biz site files.

## Got a site to show off?

<!-- If so, link to it here! -->
