### PR TITLE
Render images asynchronously

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,19 +1,12 @@
 [[source]]
-
 url = "https://pypi.python.org/simple"
 verify_ssl = true
 name = "pypi"
 
-
 [packages]
-
 "e1839a8" = {path = ".", editable = true}
-
 
 [dev-packages]
 
-
-
 [requires]
-
 python_version = "3.6"

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -37,6 +37,9 @@ def publ(name, cfg):
     app.add_url_rule('/<path:path>.PUBL_PATHALIAS',
                      'path_alias', rendering.render_path_alias)
 
+    app.add_url_rule('/_async/<path:filename>',
+                     'async', rendering.async_image)
+
     if not app.debug:
         app.register_error_handler(Exception, rendering.render_exception)
 

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -5,7 +5,7 @@ import time
 import arrow
 import flask
 
-from . import config, rendering, model, index, caching, view, utils
+from . import config, rendering, model, index, caching, view, utils, async
 
 
 def publ(name, cfg):
@@ -38,7 +38,7 @@ def publ(name, cfg):
                      'path_alias', rendering.render_path_alias)
 
     app.add_url_rule('/_async/<path:filename>',
-                     'async', rendering.async_image)
+                     'async', async.image)
 
     if not app.debug:
         app.register_error_handler(Exception, rendering.render_exception)

--- a/publ/async.py
+++ b/publ/async.py
@@ -1,6 +1,7 @@
 import os
 import time
 import io
+import hashlib
 
 import flask
 import PIL.Image

--- a/publ/async.py
+++ b/publ/async.py
@@ -1,0 +1,31 @@
+import os
+import time
+import io
+
+import flask
+import PIL.Image
+
+from . import config
+
+
+def image(filename):
+    """ Asynchronously fetch an image """
+
+    if os.path.isfile(os.path.join(config.static_folder, filename)):
+        return flask.redirect(flask.url_for('static', filename=filename))
+
+    retry_count = int(flask.request.args.get('retry_count', 0))
+    if retry_count < 3:
+        time.sleep(0.5)  # ghastly hack
+        return flask.redirect(flask.url_for('async', filename=filename, retry_count=retry_count + 1))
+
+    # the image isn't available yet; generate a placeholder and let the
+    # client attempt to re-fetch periodically, maybe
+    vals = [int(b) for b in hashlib.md5(
+        filename.encode('utf-8')).digest()[0:12]]
+    placeholder = PIL.Image.new('RGB', (2, 2))
+    placeholder.putdata(list(zip(vals[0::3], vals[1::3], vals[2::3])))
+    outbytes = io.BytesIO()
+    placeholder.save(outbytes, "PNG")
+    outbytes.seek(0)
+    return flask.send_file(outbytes, mimetype='image/png')

--- a/publ/async.py
+++ b/publ/async.py
@@ -1,3 +1,5 @@
+""" Asynchronous helper functions """
+
 import os
 import time
 import io
@@ -18,7 +20,9 @@ def image(filename):
     retry_count = int(flask.request.args.get('retry_count', 0))
     if retry_count < 10:
         time.sleep(0.1)  # ghastly hack to get the client to backoff a bit
-        return flask.redirect(flask.url_for('async', filename=filename, retry_count=retry_count + 1))
+        return flask.redirect(flask.url_for('async',
+                                            filename=filename,
+                                            retry_count=retry_count + 1))
 
     # the image isn't available yet; generate a placeholder and let the
     # client attempt to re-fetch periodically, maybe

--- a/publ/async.py
+++ b/publ/async.py
@@ -16,8 +16,8 @@ def image(filename):
         return flask.redirect(flask.url_for('static', filename=filename))
 
     retry_count = int(flask.request.args.get('retry_count', 0))
-    if retry_count < 3:
-        time.sleep(0.5)  # ghastly hack
+    if retry_count < 10:
+        time.sleep(0.1)  # ghastly hack to get the client to backoff a bit
         return flask.redirect(flask.url_for('async', filename=filename, retry_count=retry_count + 1))
 
     # the image isn't available yet; generate a placeholder and let the
@@ -29,4 +29,8 @@ def image(filename):
     outbytes = io.BytesIO()
     placeholder.save(outbytes, "PNG")
     outbytes.seek(0)
-    return flask.send_file(outbytes, mimetype='image/png')
+
+    response = flask.make_response(
+        flask.send_file(outbytes, mimetype='image/png'))
+    response.headers['Refresh'] = 5
+    return response

--- a/publ/category.py
+++ b/publ/category.py
@@ -31,7 +31,7 @@ def load_metafile(filepath):
             return email.message_from_file(file)
     except FileNotFoundError:
         logger.warning("Category file %s not found", filepath)
-        model.Category.delete().where(model.Category.file_path == fullpath).execute()
+        model.Category.delete().where(model.Category.file_path == filepath).execute()
 
     return None
 
@@ -76,6 +76,7 @@ class Category:
 
     @cached_property
     def name(self):
+        """ Get the display name of the category """
         if self._meta and self._meta.get('name'):
             # get it from the meta file
             return self._meta.get('name')
@@ -84,12 +85,14 @@ class Category:
 
     @cached_property
     def description(self):
+        """ Get the textual description of the category """
         if self._meta and self._meta.get_payload():
             return utils.TrueCallableProxy(self._description)
         return utils.CallableProxy(None)
 
     @cached_property
     def image_search_path(self):
+        """ Get the image search path for the category """
         return [os.path.join(config.content_folder, self.path)]
 
     def _description(self, **kwargs):

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -289,26 +289,3 @@ def render_entry(entry_id, slug_text='', category=''):
         tmpl,
         entry=entry_obj,
         category=Category(category)), {'Content-Type': mime_type(tmpl)}
-
-
-def async_image(filename):
-    """ Asynchronously fetch an image """
-
-    if not os.path.isfile(os.path.join(config.static_folder, filename)):
-        retry_count = int(request.args.get('retry_count', 0))
-        if retry_count < 3:
-            time.sleep(0.25)  # ghastly hack
-            return redirect(url_for('async', filename=filename, retry_count=retry_count + 1))
-
-        # the image isn't available yet; generate a placeholder and let the
-        # client attempt to re-fetch periodically, maybe
-        vals = [int(b) for b in hashlib.md5(
-            filename.encode('utf-8')).digest()[0:12]]
-        placeholder = PIL.Image.new('RGB', (2, 2))
-        placeholder.putdata(list(zip(vals[0::3], vals[1::3], vals[2::3])))
-        outbytes = io.BytesIO()
-        placeholder.save(outbytes, "PNG")
-        outbytes.seek(0)
-        return flask.send_file(outbytes, mimetype='image/png')
-
-    return redirect(url_for('static', filename=filename))

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -5,10 +5,14 @@ from __future__ import absolute_import, with_statement
 
 import os
 import logging
+import time
+import hashlib
+import io
 
 import flask
 from flask import request, redirect, render_template, url_for
 from werkzeug.exceptions import HTTPException
+import PIL.Image
 
 from . import config
 from . import path_alias
@@ -285,3 +289,26 @@ def render_entry(entry_id, slug_text='', category=''):
         tmpl,
         entry=entry_obj,
         category=Category(category)), {'Content-Type': mime_type(tmpl)}
+
+
+def async_image(filename):
+    """ Asynchronously fetch an image """
+
+    if not os.path.isfile(os.path.join(config.static_folder, filename)):
+        retry_count = int(request.args.get('retry_count', 0))
+        if retry_count < 3:
+            time.sleep(0.25)  # ghastly hack
+            return redirect(url_for('async', filename=filename, retry_count=retry_count + 1))
+
+        # the image isn't available yet; generate a placeholder and let the
+        # client attempt to re-fetch periodically, maybe
+        vals = [int(b) for b in hashlib.md5(
+            filename.encode('utf-8')).digest()[0:12]]
+        placeholder = PIL.Image.new('RGB', (2, 2))
+        placeholder.putdata(list(zip(vals[0::3], vals[1::3], vals[2::3])))
+        outbytes = io.BytesIO()
+        placeholder.save(outbytes, "PNG")
+        outbytes.seek(0)
+        return flask.send_file(outbytes, mimetype='image/png')
+
+    return redirect(url_for('static', filename=filename))

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -5,14 +5,10 @@ from __future__ import absolute_import, with_statement
 
 import os
 import logging
-import time
-import hashlib
-import io
 
 import flask
 from flask import request, redirect, render_template, url_for
 from werkzeug.exceptions import HTTPException
-import PIL.Image
 
 from . import config
 from . import path_alias


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Render images in the background, and attempt to have the client fetch them asynchronously. Implements #53 
 
## Detailed description

When images are being rendered they go into a background threadpool. Images that are being rendered asynchronously get returned with a special `_async` handler, which retries loading the image a few times (with a short backoff) and then returns a generated gradient image if it fails.

Unfortunately WSGI (and therefore Flask) is blocking and can't do proper async, so the hope is that the redirect causes the client to reorder its pending resource fetches.

At some point there should be a client-side JS library that detects the async/deferred images and attempts to reload them periodically. However, the gradient acts as an indicator that the user can refresh the page and maybe it'll work.

## Test plan

hammered on local instance of giant comics site, apparent speed was way better

