### PR TITLE
Use local dates for pagination and sorting

### DIFF
--- a/publ/category.py
+++ b/publ/category.py
@@ -179,12 +179,12 @@ class Category:
     def _first(self, **spec):
         """ Get the earliest entry in this category, optionally including subcategories """
         return entry.Entry(self._entries(spec).order_by(
-            model.Entry.utc_date, model.Entry.id).get())
+            model.Entry.local_date, model.Entry.id).get())
 
     def _last(self, **spec):
         """ Get the latest entry in this category, optionally including subcategories """
         return entry.Entry(self._entries(spec).order_by(
-            -model.Entry.utc_date, -model.Entry.id).get())
+            -model.Entry.local_date, -model.Entry.id).get())
 
 
 def scan_file(fullpath, relpath):

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -205,7 +205,7 @@ class Entry:
         return self._get_first(model.Entry.select().where(
             queries.build_query(spec) &
             queries.where_before_entry(self._record)
-        ).order_by(-model.Entry.utc_date, -model.Entry.id))
+        ).order_by(-model.Entry.local_date, -model.Entry.id))
 
     def _next(self, **kwargs):
         """ Get the next item in any particular category """
@@ -216,7 +216,7 @@ class Entry:
             model.Entry.select().where(
                 queries.build_query(spec) &
                 queries.where_after_entry(self._record)
-            ).order_by(model.Entry.utc_date, model.Entry.id))
+            ).order_by(model.Entry.local_date, model.Entry.id))
 
     def get(self, name):
         """ Get a single header on an entry """

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -347,8 +347,9 @@ def scan_file(fullpath, relpath, assign_id):
                 os.stat(fullpath).st_ctime).to(config.timezone)
             entry['Date'] = entry_date.format()
 
-        values['utc_date'] = entry_date.to('utc').datetime
         values['display_date'] = entry_date.datetime
+        values['utc_date'] = entry_date.to('utc').datetime
+        values['local_date'] = entry_date.naive
 
         logger.debug("getting entry %s with id %d", fullpath, entry_id)
         record, created = model.Entry.get_or_create(

--- a/publ/model.py
+++ b/publ/model.py
@@ -19,7 +19,7 @@ lock = threading.Lock()  # pylint: disable=invalid-name
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 # Schema version; bump this whenever an existing table changes
-SCHEMA_VERSION = 8
+SCHEMA_VERSION = 10
 
 
 class BaseModel(Model):
@@ -69,8 +69,9 @@ class Entry(BaseModel):
     file_path = CharField()
     category = CharField()
     status = PublishStatus.Field()
-    utc_date = DateTimeField()  # UTC-normalized, for queries
-    display_date = DateTimeField()  # arbitrary timezone, for display
+    utc_date = DateTimeField()  # UTC-normalized, for ordering and visibility
+    local_date = DateTimeField()  # arbitrary timezone, for pagination
+    display_date = DateTimeField()  # The actual displayable date
     slug_text = CharField()
     entry_type = CharField()
     redirect_url = CharField(null=True)
@@ -81,6 +82,7 @@ class Entry(BaseModel):
         # pylint: disable=too-few-public-methods
         indexes = (
             (('category', 'entry_type', 'utc_date'), False),
+            (('category', 'entry_type', 'local_date'), False)
         )
 
 

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -121,8 +121,8 @@ def where_entry_date(datespec):
     date, interval, _ = utils.parse_date(datespec)
     start_date, end_date = date.span(interval)
 
-    return ((model.Entry.utc_date >= start_date.to('utc').datetime) &
-            (model.Entry.utc_date <= end_date.to('utc').datetime))
+    return ((model.Entry.local_date >= start_date.naive) &
+            (model.Entry.local_date <= end_date.naive))
 
 
 def get_entry(entry):

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -54,8 +54,8 @@ def where_before_entry(entry):
 
     entry -- The entry of reference
     """
-    return (model.Entry.utc_date < entry.utc_date) | (
-        (model.Entry.utc_date == entry.utc_date) &
+    return (model.Entry.local_date < entry.local_date) | (
+        (model.Entry.local_date == entry.local_date) &
         (model.Entry.id < entry.id)
     )
 
@@ -65,8 +65,8 @@ def where_after_entry(entry):
 
     entry -- the entry of reference
     """
-    return (model.Entry.utc_date > entry.utc_date) | (
-        (model.Entry.utc_date == entry.utc_date) &
+    return (model.Entry.local_date > entry.local_date) | (
+        (model.Entry.local_date == entry.local_date) &
         (model.Entry.id > entry.id)
     )
 
@@ -76,8 +76,8 @@ def where_entry_last(entry):
 
     entry -- the entry of reference
     """
-    return (model.Entry.utc_date < entry.utc_date) | (
-        (model.Entry.utc_date == entry.utc_date) &
+    return (model.Entry.local_date < entry.local_date) | (
+        (model.Entry.local_date == entry.local_date) &
         (model.Entry.id <= entry.id)
     )
 
@@ -87,8 +87,8 @@ def where_entry_first(entry):
 
     entry -- the entry of reference
     """
-    return (model.Entry.utc_date > entry.utc_date) | (
-        (model.Entry.utc_date == entry.utc_date) &
+    return (model.Entry.local_date > entry.local_date) | (
+        (model.Entry.local_date == entry.local_date) &
         (model.Entry.id >= entry.id)
     )
 

--- a/publ/view.py
+++ b/publ/view.py
@@ -25,14 +25,14 @@ PAGINATION_SPECS = OFFSET_PRIORITY + PAGINATION_PRIORITY
 
 #: Ordering queries for different sort orders
 ORDER_BY = {
-    'newest': [-model.Entry.utc_date, -model.Entry.id],
-    'oldest': [model.Entry.utc_date, model.Entry.id],
+    'newest': [-model.Entry.local_date, -model.Entry.id],
+    'oldest': [model.Entry.local_date, model.Entry.id],
     'title': [model.Entry.title, model.Entry.id]
 }
 
 REVERSE_ORDER_BY = {
-    'newest': [model.Entry.utc_date, model.Entry.id],
-    'oldest': [-model.Entry.utc_date, -model.Entry.id],
+    'newest': [model.Entry.local_date, model.Entry.id],
+    'oldest': [-model.Entry.local_date, -model.Entry.id],
     'title': [-model.Entry.title, -model.Entry.id]
 }
 
@@ -234,7 +234,7 @@ class View:
         _, _, date_format = utils.parse_date(self.spec['date'])
 
         if newest_neighbor:
-            newer_date = newest_neighbor.date.to(config.timezone)
+            newer_date = newest_neighbor.date
             newer_view = View({**base,
                                'order': self._order_by,
                                'date': newer_date.format(date_format)})
@@ -242,7 +242,7 @@ class View:
             newer_view = None
 
         if oldest_neighbor:
-            older_date = oldest_neighbor.date.to(config.timezone)
+            older_date = oldest_neighbor.date
             older_view = View({**base,
                                'order': self._order_by,
                                'date': older_date.format(date_format)})


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #91 

## Detailed description

Entries now have three (3) date fields! One for UTC time (used only for visibility determination), one for local time (used for pagination and sorting), and one for canonical entry time (used for display and `.humanize()`).

The UTC date is probably not necessary anymore, as peewee seems to support timezone-aware datetimes and we can probably just use that for the filter criterion.

## Developer/user impact

None

## Test plan

Generated a bunch of random test entries with varying timezones and determined that sorting and pagination were working correctly. These will be at http://publ.beesbuzz.biz/tests/date-based when published.
