### PR TITLE
Add CSS background-image generator

### DIFF
--- a/publ/image.py
+++ b/publ/image.py
@@ -232,11 +232,11 @@ class LocalImage(Image):
                     temp_path = file.name
                     image.save(file, **out_args)
                 shutil.move(temp_path, path)
-            except Exception:
+
+                logger.info("%s: complete", path)
+            except Exception:  # pylint: disable=broad-exception
                 logger.exception("Failed to render %s -> %s",
                                  self._record.file_path, path)
-
-            logger.info("%s: complete", path)
 
     def get_rendition_size(self, spec, output_scale):
         """
@@ -417,6 +417,7 @@ class LocalImage(Image):
         return image.convert('RGB')
 
     def get_img_tag(self, title='', alt_text='', **kwargs):
+        """ Get an <img> tag for this image, hidpi-aware """
 
         # Get the 1x and 2x renditions
         img_1x, size = self.get_rendition(
@@ -435,6 +436,22 @@ class LocalImage(Image):
 
         # Wrap it in a link as appropriate
         return flask.Markup(self._wrap_link_target(kwargs, text, title))
+
+    def get_css_background(self, **kwargs):
+        """ Get the CSS specifiers for this as a hidpi-capable background image """
+
+        # Get the 1x and 2x renditions
+        img_1x, _ = self.get_rendition(
+            1, **utils.remap_args(kwargs, {"quality": "quality_ldpi"}))
+        img_2x, _ = self.get_rendition(
+            2, **utils.remap_args(kwargs, {"quality": "quality_hdpi"}))
+
+        tmpl = 'background-image: url("{s1x}");'
+        if img_1x != img_2x:
+            image_set = 'image-set(url("{s1x}") 1x, url("{s2x}") 2x)'
+            tmpl += 'background-image: {ss};background-image: -webkit-{ss};'.format(
+                ss=image_set)
+        return tmpl.format(s1x=img_1x, s2x=img_2x)
 
 
 class RemoteImage(Image):
@@ -483,6 +500,9 @@ class RemoteImage(Image):
 
         return self._wrap_link_target(kwargs, utils.make_tag('img', attrs), title)
 
+    def get_css_background(self, **kwargs):
+        return 'background-image: url("{}");'.format(self.url)
+
 
 class StaticImage(Image):
     """ An image that points to a static resource """
@@ -498,6 +518,10 @@ class StaticImage(Image):
     def get_img_tag(self, title='', alt_text='', **kwargs):
         url = utils.static_url(self.path, absolute=kwargs.get('absolute'))
         return RemoteImage(url).get_img_tag(title, alt_text, **kwargs)
+
+    def get_css_background(self, **kwargs):
+        url = utils.static_url(self.path, absolute=kwargs.get('absolute'))
+        return RemoteImage(url).get_css_background(title, alt_text, **kwargs)
 
 
 class ImageNotFound(Image):
@@ -519,6 +543,9 @@ class ImageNotFound(Image):
             text += ' (Did you forget a <code>|</code>?)'
         text += '</span>'
         return text
+
+    def get_css_background(self, **kwargs):
+        return '/* not found: {} */'.format(self.path)
 
 
 def get_image(path, search_path):

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -89,8 +89,7 @@ def image_function(template=None, entry=None, category=None):
     if template is not None:
         path.append(os.path.join(
             config.content_folder,
-            os.path.dirname(os.path.relpath(template.filename,
-                                            config.template_folder))))
+            os.path.dirname(template.filename)))
 
     return lambda filename: image.get_image(filename, path)
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #94
<!-- Summary of the PR; please link to any issue(s) that this solves -->

## Detailed description

The Image object returned by `image()` now supports a `get_css_background()` method, which returns the complete CSS attributes needed to use the image as a background-image.

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

## Developer/user impact

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

## Got a site to show off?

<!-- If so, link to it here! -->
