### PR TITLE
Support Markdown in entry titles

### DIFF
--- a/publ/entry.py
+++ b/publ/entry.py
@@ -151,7 +151,7 @@ class Entry:
         return CallableProxy(self._title)
 
     def _title(self, markup=True):
-        return markdown.title(self._record.title, markup)
+        return markdown.render_title(self._record.title, markup)
 
     @cached_property
     def image_search_path(self):

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -52,17 +52,63 @@ class Entry:
         self._record = record   # index record
         self._message = None    # actual message payload, lazy-loaded
 
-        self.date = arrow.get(record.display_date)
+    @cached_property
+    def date(self):
+        """ Get the display date of the entry, as an Arrow object """
+        return arrow.get(self._record.display_date)
 
-        self.link = CallableProxy(self._link)
-        self.permalink = CallableProxy(self._permalink)
-        self.archive = CallableProxy(self._archive_link)
+    @cached_property
+    def link(self):
+        """ Get a link to this entry. Accepts the same parameters as permalink;
+        may be pre-redirected. """
+        return CallableProxy(self._link)
 
-        self.next = CallableProxy(self._next)
-        self.previous = CallableProxy(self._previous)
+    @cached_property
+    def permalink(self):
+        """ Get a canonical link to this entry. Accepts the following parameters:
 
+        absolute -- if True, return an absolute/portable link (default: False)
+        expand -- if True, expands the link to include the category and slug text;
+            if False, it will only be the entry ID (default: True)
+        """
+        return CallableProxy(self._permalink)
+
+    @cached_property
+    def archive(self):
+        """ Get a link to this entry in the context of a category template.
+        Accepts the following arguments:
+
+        paging -- Which pagination scheme to use; one of:
+            day -- the entry date's day
+            month -- the entry date's month
+            year -- the entry date's year
+            offset -- count-based pagination starting at the entry (default)
+        category -- Which category to generate the link against (default: the entry's category)
+        template -- Which template to generate the link for
+        """
+        return CallableProxy(self._archive_link)
+
+    @cached_property
+    def next(self):
+        """ Get the next entry in the category, ordered by date.
+
+        Accepts view parameters as arguments.
+        """
+        return CallableProxy(self._next)
+
+    @cached_property
+    def previous(self):
+        """ Get the previous entry in the category, ordered by date.
+
+        Accepts view parameters as arguments.
+        """
+        return CallableProxy(self._previous)
+
+    @cached_property
+    def category(self):
+        """ Get the category this entry belongs to. """
         from .category import Category  # pylint: disable=cyclic-import
-        self.category = Category(record.category)
+        return Category(self._record.category)
 
     def _link(self, *args, **kwargs):
         """ Returns a link, potentially pre-redirected """
@@ -94,6 +140,18 @@ class Entry:
             args['start'] = self._record.id
 
         return flask.url_for('category', **args, _external=absolute)
+
+    @cached_property
+    def title(self):
+        """ Get the title of the entry. Accepts the following argument:
+
+        markup -- If True, convert it from Markdown to HTML; otherwise, strip
+            all markdown (default: True)
+        """
+        return CallableProxy(self._title)
+
+    def _title(self, markup=True):
+        return markdown.title(self._record.title, markup)
 
     @cached_property
     def image_search_path(self):
@@ -147,10 +205,11 @@ class Entry:
             kwargs -- parameters to pass to the Markdown processor
         """
         if is_markdown:
-            return flask.Markup(markdown.to_html(
+            return markdown.to_html(
                 text,
                 config=kwargs,
-                image_search_path=self.image_search_path))
+                image_search_path=self.image_search_path)
+
         return flask.Markup(text)
 
     def _get_card(self, text, **kwargs):
@@ -233,7 +292,7 @@ class Entry:
         if isinstance(other, int):
             return other == self._record.id
         # pylint:disable=protected-access
-        return other is self or other._record == self._record
+        return isinstance(other, Entry) and (other is self or other._record == self._record)
 
 
 def guess_title(basename):

--- a/publ/image.py
+++ b/publ/image.py
@@ -47,7 +47,23 @@ class Image:
         """ Implemented by the subclasses for actually emitting the HTML """
         pass
 
-    def get_css_background(self, **kwargs):
+    def get_css_background(self, uncomment=False, **kwargs):
+        """ Get the CSS background attributes for an element.
+
+        Additional arguments:
+
+        uncomment -- surround the attributes with `*/` and `/*` so that the
+            template tag can be kept inside a comment block, to keep syntax
+            highlighters happy
+        """
+
+        text = self._css_background(**kwargs)
+        if uncomment:
+            text = ' */ {} /* '.format(text)
+
+        return text
+
+    def _css_background(self, **kwargs):
         """ Build CSS background-image properties that apply this image.
 
         Returns: a CSS fragment. """
@@ -434,9 +450,9 @@ class LocalImage(Image):
             'srcset': "{} 1x, {} 2x".format(img_1x, img_2x) if img_1x != img_2x else None,
             'title': title,
             'alt': alt_text
-        })
+        }, start_end=kwargs.get('xhtml'))
 
-    def get_css_background(self, **kwargs):
+    def _css_background(self, **kwargs):
         """ Get the CSS specifiers for this as a hidpi-capable background image """
 
         # Get the 1x and 2x renditions
@@ -497,9 +513,9 @@ class RemoteImage(Image):
         attrs['width'] = width
         attrs['height'] = height
 
-        return utils.make_tag('img', attrs)
+        return utils.make_tag('img', attrs, start_end=kwargs.get('xhtml'))
 
-    def get_css_background(self, **kwargs):
+    def _css_background(self, **kwargs):
         """ Get the CSS background-image for the remote image """
         return 'background-image: url("{}");'.format(self.url)
 
@@ -544,7 +560,7 @@ class ImageNotFound(Image):
         text += '</span>'
         return flask.Markup(text)
 
-    def get_css_background(self, **kwargs):
+    def _css_background(self, **kwargs):
         return '/* not found: {} */'.format(self.path)
 
 

--- a/publ/image.py
+++ b/publ/image.py
@@ -531,11 +531,12 @@ class StaticImage(Image):
         url = utils.static_url(self.path, absolute=kwargs.get('absolute'))
         return RemoteImage(url).get_rendition(output_scale, **kwargs)
 
-    def _img_tag(self, title='', alt_text='', **kwargs):
+    def get_img_tag(self, title='', alt_text='', **kwargs):
         url = utils.static_url(self.path, absolute=kwargs.get('absolute'))
         return RemoteImage(url).get_img_tag(title, alt_text, **kwargs)
 
     def get_css_background(self, **kwargs):
+        # pylint: disable=arguments-differ
         url = utils.static_url(self.path, absolute=kwargs.get('absolute'))
         return RemoteImage(url).get_css_background(**kwargs)
 

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -173,12 +173,11 @@ class HTMLStripper(html.parser.HTMLParser):
 
 def render_title(text, markup=True):
     """ Convert a Markdown title to HTML """
-    text = flask.Markup(misaka.Markdown(
-        TitleRenderer(), extensions=TITLE_EXTENSIONS)(text))
+    text = misaka.Markdown(TitleRenderer(), extensions=TITLE_EXTENSIONS)(text)
 
-    if markup:
-        return text
+    if not markup:
+        strip = HTMLStripper()
+        strip.feed(text)
+        text = strip.get_data()
 
-    strip = HTMLStripper()
-    strip.feed(text)
-    return strip.get_data()
+    return flask.Markup(text)

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -27,7 +27,9 @@ class HtmlRenderer(misaka.HtmlRenderer):
     """ Customized renderer for enhancing Markdown formatting """
 
     def __init__(self, config, image_search_path):
+        # pylint: disable=no-member
         super().__init__(0, config.get('xhtml') and misaka.HTML_USE_XHTML or 0)
+
         self._config = config
         self._image_search_path = image_search_path
 
@@ -138,6 +140,7 @@ def to_html(text, config, image_search_path):
 
 class TitleRenderer(misaka.HtmlRenderer):
     """ A renderer that is suitable for rendering out page titles and nothing else """
+    # pylint: disable=missing-docstring
 
     def __init__(self, markup):
         super().__init__()
@@ -220,6 +223,7 @@ class TitleRenderer(misaka.HtmlRenderer):
 
     def math(self, text, displaymode):
         if self._markup:
+            # pylint: disable=no-member
             return super().math(text, displaymode)
         return text
 
@@ -233,6 +237,6 @@ class TitleRenderer(misaka.HtmlRenderer):
         return text
 
 
-def title(text, markup=True):
+def render_title(text, markup=True):
     """ Convert a Markdown title to HTML """
     return flask.Markup(misaka.Markdown(TitleRenderer(markup), extensions=TITLE_EXTENSIONS)(text))


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #99
<!-- Summary of the PR; please link to any issue(s) that this solves -->

## Detailed description

When rendering a title, run it through Markdown, but with all `<p>` tags removed. Also, adds an optional argument, `markup`, which will strip out all other tags when false.

As a bonus, `body` and `more` now get a parameter, `xhtml=True`, to render XHTML instead of plain HTML. This turns out to not be particularly useful, although maybe someone will need it in the future.

Also, as part of ongoing documentation cleanup efforts, `Entry`'s `CallableProxy` properties are now done as `@cached_property` getters.

## Developer/user impact

Templates now need to specify `{{ entry.title(markup=False) }}` wherever a title can be used where markup isn't permitted (such as in `<title>` elements on HTML and Atom).

## Test plan

Thorough tests on the publ.beesbuzz.biz site files

