### PR TITLE
Improve errors during reindexing

### DIFF
--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -4,6 +4,7 @@ import time
 
 import arrow
 import flask
+import werkzeug.exceptions
 
 from . import config, rendering, model, index, caching, view, utils, async
 
@@ -41,6 +42,10 @@ def publ(name, cfg):
                      'async', async.image)
 
     app.add_url_rule('/_', 'chit', rendering.render_transparent_chit)
+
+    app.config['TRAP_HTTP_EXCEPTIONS'] = True
+    app.register_error_handler(
+        werkzeug.exceptions.HTTPException, rendering.render_exception)
 
     if not app.debug:
         app.register_error_handler(Exception, rendering.render_exception)

--- a/publ/category.py
+++ b/publ/category.py
@@ -200,13 +200,19 @@ class Category:
 
     def _first(self, **spec):
         """ Get the earliest entry in this category, optionally including subcategories """
-        return entry.Entry(self._entries(spec).order_by(
-            model.Entry.local_date, model.Entry.id).get())
+        try:
+            return entry.Entry(self._entries(spec).order_by(
+                model.Entry.local_date, model.Entry.id).get())
+        except model.Entry.DoesNotExist:
+            return None
 
     def _last(self, **spec):
         """ Get the latest entry in this category, optionally including subcategories """
-        return entry.Entry(self._entries(spec).order_by(
-            -model.Entry.local_date, -model.Entry.id).get())
+        try:
+            return entry.Entry(self._entries(spec).order_by(
+                -model.Entry.local_date, -model.Entry.id).get())
+        except model.Entry.DoesNotExist:
+            return None
 
 
 def scan_file(fullpath, relpath):

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -137,7 +137,7 @@ class Entry:
         elif paging == 'year':
             args['date'] = self.date.format(utils.YEAR_FORMAT)
         elif paging == 'offset' or not paging:
-            args['id'] = self._record.id
+            args['start'] = self._record.id
         else:
             raise ValueError("Unknown paging type '{}'".format(paging))
 

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -139,7 +139,7 @@ class Entry:
         elif paging == 'offset' or not paging:
             args['id'] = self._record.id
         else:
-            raise ValueError("Unknown paging type '%s'", paging)
+            raise ValueError("Unknown paging type '{}'".format(paging))
 
         return flask.url_for('category', **args, _external=absolute)
 

--- a/publ/index.py
+++ b/publ/index.py
@@ -23,6 +23,10 @@ thread_pool = concurrent.futures.ThreadPoolExecutor(  # pylint: disable=invalid-
     thread_name_prefix="Indexer")
 
 
+def is_indexing():
+    return not thread_pool._work_queue.empty()
+
+
 def scan_file(fullpath, relpath, assign_id):
     """ Scan a file for the index
 

--- a/publ/index.py
+++ b/publ/index.py
@@ -4,7 +4,6 @@
 import os
 import logging
 import concurrent.futures
-import queue
 
 import watchdog.observers
 import watchdog.events
@@ -28,6 +27,7 @@ WORK_QUEUE = getattr(THREAD_POOL, '_work_queue', None)
 
 
 def queue_length():
+    """ Get the approximate length of the indexer work queue """
     return WORK_QUEUE.qsize() if WORK_QUEUE else None
 
 

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -170,6 +170,7 @@ class TitleRenderer(HtmlRenderer):
 
     @staticmethod
     def header(content, level):
+        # pylint: disable=unused-argument
         return content
 
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -220,7 +220,7 @@ def render_category(category='', template=None):
         raise http_error.NotFound("No such view")
 
     view_spec = {'category': category}
-    for key in ['date', 'id']:
+    for key in ['date', 'start']:
         if key in request.args:
             view_spec[key] = request.args[key]
 

--- a/publ/view.py
+++ b/publ/view.py
@@ -11,7 +11,7 @@ from . import model, utils, queries
 from .entry import Entry
 
 # Prioritization list for pagination
-OFFSET_PRIORITY = ['date', 'id', 'last', 'first']
+OFFSET_PRIORITY = ['date', 'start', 'last', 'first']
 
 # Prioritization list for pagination type
 #
@@ -71,11 +71,11 @@ class View:
 
         self.spec = spec
 
-        if 'id' in spec:
+        if 'start' in spec:
             if self._order_by == 'oldest':
-                self.spec['first'] = self.spec['id']
+                self.spec['first'] = self.spec['start']
             elif self._order_by == 'newest':
-                self.spec['last'] = self.spec['id']
+                self.spec['last'] = self.spec['start']
 
         self._where = queries.build_query(spec)
         self._query = model.Entry.select().where(self._where)
@@ -108,10 +108,10 @@ class View:
                 if k in self.spec:
                     val = self.spec[k]
                     if isinstance(val, (str, int)):
-                        args['id'] = val
-                    elif hasattr(val, 'id'):
+                        args['start'] = val
+                    elif hasattr(val, 'start'):
                         # the item was an object, so we want the object's id
-                        args['id'] = val.id
+                        args['start'] = val.id
                     else:
                         raise ValueError(
                             "key {} is of type {}".format(k, type(val)))


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #104 

## Detailed description

A refactor of the way error pages work, which also makes NotFound errors get promoted to a 503 with an appropriate retry header if the site is currently being reindexed.

## Test plan

Hammered at reloading while reindexing beesbuzz.biz

