### PR TITLE
Add the get_template() function for including sub-template fragments

### DIFF
--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -50,7 +50,8 @@ def publ(name, cfg):
     app.jinja_env.globals.update(  # pylint: disable=no-member
         get_view=view.get_view,
         arrow=arrow,
-        static=utils.static_url
+        static=utils.static_url,
+        fragment=rendering.fragment
     )
 
     caching.init_app(app)

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -51,7 +51,7 @@ def publ(name, cfg):
         get_view=view.get_view,
         arrow=arrow,
         static=utils.static_url,
-        fragment=rendering.fragment
+        get_template=rendering.get_template
     )
 
     caching.init_app(app)

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -72,7 +72,7 @@ def map_template(category, template_list):
                 path = None
 
 
-def fragment(template, relation):
+def get_template(template, relation):
     """ Given an entry or a category, return the path to a related template """
     if isinstance(relation, Entry):
         path = relation.category.path
@@ -82,9 +82,7 @@ def fragment(template, relation):
         path = relation
 
     tmpl = map_template(path, template)
-    if tmpl:
-        return tmpl.filename
-    return None
+    return tmpl.filename if tmpl else None
 
 
 def get_redirect():
@@ -103,7 +101,7 @@ def image_function(template=None, entry=None, category=None):
     if entry is not None:
         path += entry.image_search_path
     if category is not None:
-        # Since the category might be a parent of the entry's category we add
+        # Since the category might be different than the entry's category we add
         # this too
         path += category.image_search_path
     if template is not None:

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -72,6 +72,21 @@ def map_template(category, template_list):
                 path = None
 
 
+def fragment(template, relation):
+    """ Given an entry or a category, return the path to a related template """
+    if isinstance(relation, Entry):
+        path = relation.category.path
+    elif isinstance(relation, Category):
+        path = relation.path
+    else:
+        path = relation
+
+    tmpl = map_template(path, template)
+    if tmpl:
+        return tmpl.filename
+    return None
+
+
 def get_redirect():
     """ Check to see if the current request is a redirection """
     alias = path_alias.get_redirect([request.full_path, request.path])


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes #90 

## Detailed description

Adds a template function, `get_template()`, that can be used in conjunction with Jinja's `include` predicate.

## Test plan

Tests added to publ.beesbuzz.biz in the `tests/subtemplate` section.

Production-worthy usage on beesbuzz.biz.
