### PR TITLE
Disable cache during index

### DIFF
--- a/publ/index.py
+++ b/publ/index.py
@@ -31,6 +31,11 @@ def queue_length():
     return WORK_QUEUE.qsize() if WORK_QUEUE else None
 
 
+def in_progress():
+    """ Return if there's an index in progress """
+    return queue_length() > 0
+
+
 def scan_file(fullpath, relpath, assign_id):
     """ Scan a file for the index
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -193,7 +193,7 @@ def render_path_alias(path):
     return redir
 
 
-@cache.cached(key_prefix=caching.make_category_key)
+@cache.cached(key_prefix=caching.make_category_key, unless=index.in_progress)
 def render_category(category='', template=None):
     """ Render a category page.
 
@@ -249,7 +249,7 @@ def render_category(category='', template=None):
         view=view_obj), {'Content-Type': mime_type(tmpl)}
 
 
-@cache.cached(key_prefix=caching.make_entry_key)
+@cache.cached(key_prefix=caching.make_entry_key, unless=index.in_progress)
 def render_entry(entry_id, slug_text='', category=''):
     """ Render an entry page.
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Disable caching during site index; fixes #84 

## Detailed description

Simply uses Flask-Caching's `unless` function. Easy.

