### PR TITLE
Path-Alias regex hook

### DIFF
--- a/publ/path_alias.py
+++ b/publ/path_alias.py
@@ -3,7 +3,7 @@
 
 from __future__ import absolute_import, with_statement
 
-from flask import url_for, redirect
+from flask import url_for, redirect, current_app
 
 from . import model
 
@@ -104,6 +104,10 @@ def get_redirect(paths):
 
     for path in paths:
         url, permanent = get_alias(path)
+        if url:
+            return redirect(url, 301 if permanent else 302)
+
+        url, permanent = current_app.get_path_regex(path)
         if url:
             return redirect(url, 301 if permanent else 302)
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -90,6 +90,7 @@ def get_redirect():
     alias = path_alias.get_redirect([request.full_path, request.path])
     if alias:
         return alias
+
     return None
 
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -87,7 +87,7 @@ def get_template(template, relation):
 
 def get_redirect():
     """ Check to see if the current request is a redirection """
-    alias = path_alias.get_redirect([request.full_path, request.path])
+    alias = path_alias.get_redirect(request.path)
     if alias:
         return alias
 


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

This allows sites to declare their own path-alias regular expression rules that are evaluated after the built-in path-alias logic.

## Detailed description

```
app = publ.publ(__name__, config)

# Rewrite old comic URLs to date-based views; ideally this should be a feature in
# Publ itself. See https://github.com/fluffy-critter/Publ/issues/11
import flask


@app.path_alias_regex(r'/d/([0-9]{8}(_w)?)\.php')
def redirect_date(match):
    return flask.url_for('category', category='comics', date=match.group(1)), True
```

## Test plan

Tested on beesbuzz.biz
