### PR TITLE
Automatically purge image rendition cache

### DIFF
--- a/publ/config.py
+++ b/publ/config.py
@@ -13,6 +13,8 @@ static_folder = 'static'
 static_url_path = '/static'
 image_output_subdir = '_img'
 index_rescan_interval = 7200
+image_cache_interval = 3600
+image_cache_age = 86400 * 7
 timezone = tz.tzlocal()
 cache = {}
 

--- a/publ/maintenance.py
+++ b/publ/maintenance.py
@@ -1,9 +1,6 @@
 """ Periodic maintenance tasks """
 
-import os
 import time
-
-from . import config
 
 
 class Maintenance:
@@ -13,9 +10,12 @@ class Maintenance:
         self.tasks = {}
 
     def register(self, func, interval):
+        """ Registers a task to run periodically """
         self.tasks[func] = {'interval': interval}
 
     def run(self, force=False):
+        """ Run all pending tasks; 'force' will run all tasks whether they're
+        pending or not. """
         now = time.time()
         for func, spec in self.tasks.items():
             if force or now >= spec.get('next_run', 0):

--- a/publ/maintenance.py
+++ b/publ/maintenance.py
@@ -1,0 +1,23 @@
+""" Periodic maintenance tasks """
+
+import os
+import time
+
+from . import config
+
+
+class Maintenance:
+    """ Container for periodic maintenance tasks """
+
+    def __init__(self):
+        self.tasks = {}
+
+    def register(self, func, interval):
+        self.tasks[func] = {'interval': interval}
+
+    def run(self, force=False):
+        now = time.time()
+        for func, spec in self.tasks.items():
+            if force or now >= spec.get('next_run', 0):
+                func()
+                spec['next_run'] = now + spec['interval']


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Fixes issue #102, and automatically cleans old image renditions from the rendition cache.

<!-- Summary of the PR; please link to any issue(s) that this solves -->

## Detailed description

When an image rendition is used, the file timestamp gets touched, marking the rendition as recently-used.

A periodic maintenance process (default: once an hour) now scans the image rendition cache for renditions that haven't been used in a while (default: one week) and removes them.

Maintenance tasks are also now encapsulated in a recurring task scheduler, which presently only runs whenever a request occurs (rather than using a background thread).

<!--
 Please explain what this PR does and how it does it, and provide examples
 of how it would be used in a template or entry or how it fixes existing behavior
-->

## Developer/user impact

Stale images no longer take up disk space indefinitely. On the plus side this saves space; on the minus side this means that images on infrequently-accessed content pages may become invalid for the purposes of image search or hotlinks or whatever.

<!--
 Does this change affect any existing templating behavior or the way that users
 deploy their sites? If so, please describe these changes and how a user might
 need to respond.
-->

## Test plan

<!--
 How did you test this change? How might someone else test it to
 verify it?
-->

manually smoke tested with beesbuzz.biz

## Got a site to show off?

<!-- If so, link to it here! -->
