### PR TITLE
Replace peewee with Pony

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__
 build/
 dist/
 Publ.egg-info/
+*.db

--- a/Pipfile
+++ b/Pipfile
@@ -6,7 +6,7 @@ name = "pypi"
 [packages]
 "e1839a8" = {path = ".", editable = true}
 twine = "*"
+pony = "*"
 
 [dev-packages]
 pylint = "*"
-

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b0285b5047521bac17fcfe99865bf5d6d49794d1712c4b7c6d1c6326b4fd201d"
+            "sha256": "8f2de1bdcc279950426a03add5e09aba75f3ea38c6c9383c67df47b84374efa0"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -147,12 +147,6 @@
             ],
             "version": "==0.1.2"
         },
-        "peewee": {
-            "hashes": [
-                "sha256:bb9ee5e2ca601c82f5e3c8327f19af4b5f9941ae74ec520674165692d3d6ae7a"
-            ],
-            "version": "==3.7.0"
-        },
         "pillow": {
             "hashes": [
                 "sha256:00def5b638994f888d1058e4d17c86dec8e1113c3741a0a8a659039aec59a83a",
@@ -195,6 +189,15 @@
                 "sha256:a39076cb3eb34c333a0dd390b568e9e1e881c7bf2cc0aee12120636816f55aee"
             ],
             "version": "==1.4.2"
+        },
+        "pony": {
+            "hashes": [
+                "sha256:0d72f4ab9d50d42f275606c0c2812aa704bf3a37ac8f2a60c9892eff3f90d615",
+                "sha256:b18434011c03c2981e44a2cfbbaeec4bdebe30adb434d1dfd6be8f59d07f37bd",
+                "sha256:c6dee426b50001a5cf984f201b2b61d66acd8f5018813e3a587467971f30ec2a"
+            ],
+            "index": "pypi",
+            "version": "==0.7.6"
         },
         "pycparser": {
             "hashes": [

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -135,7 +135,9 @@ last_scan = None  # pylint: disable=invalid-name
 
 def startup():
     """ Startup routine for initiating the content indexer """
+    print("setup")
     model.setup()
+    print("scan_index")
     index.scan_index(config.content_folder)
     index.background_scan(config.content_folder)
 

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -135,9 +135,7 @@ last_scan = None  # pylint: disable=invalid-name
 
 def startup():
     """ Startup routine for initiating the content indexer """
-    print("setup")
     model.setup()
-    print("scan_index")
     index.scan_index(config.content_folder)
     index.background_scan(config.content_folder)
 

--- a/publ/__init__.py
+++ b/publ/__init__.py
@@ -7,6 +7,7 @@ import functools
 import arrow
 import flask
 import werkzeug.exceptions
+from pony.orm import db_session
 
 from . import config, rendering, model, index, caching, view, utils
 from . import maintenance, image

--- a/publ/category.py
+++ b/publ/category.py
@@ -32,7 +32,8 @@ def load_metafile(filepath):
             return email.message_from_file(file)
     except FileNotFoundError:
         logger.warning("Category file %s not found", filepath)
-        model.Category.delete().where(model.Category.file_path == filepath).execute()
+        orm.delete(c for c in model.Category if c.file_path == filepath)
+        orm.commit()
 
     return None
 

--- a/publ/category.py
+++ b/publ/category.py
@@ -11,6 +11,7 @@ import functools
 import flask
 from flask import url_for
 from werkzeug.utils import cached_property
+from pony import orm
 
 from . import model
 from . import utils
@@ -46,6 +47,9 @@ class Category:
         path -- the path to the category
         """
 
+        if path is None:
+            path = ''
+
         self.path = path
         self.basename = os.path.basename(path)
 
@@ -65,8 +69,7 @@ class Category:
         self.first = utils.CallableProxy(self._first)
         self.last = utils.CallableProxy(self._last)
 
-        self._record = model.Category.get_or_none(
-            model.Category.category == path)
+        self._record = model.Category.get(category=path)
 
     @cached_property
     def _meta(self):

--- a/publ/category.py
+++ b/publ/category.py
@@ -60,8 +60,7 @@ class Category:
                 c for c in subcat_query if c.startswith(path + '/'))
         else:
             subcat_query = orm.select(c for c in subcat_query if c != '')
-
-        self._subcats_recursive = subcat_query.order_by(lambda c: c)
+        self._subcats_recursive = subcat_query
 
         self.link = utils.CallableProxy(self._link)
 
@@ -179,7 +178,7 @@ class Category:
 
         if recurse:
             # No need to filter
-            return [Category(e.category) for e in self._subcats_recursive]
+            return [Category(e) for e in self._subcats_recursive]
 
         # get all the subcategories, with only the first subdir added
 
@@ -187,7 +186,7 @@ class Category:
         parts = len(self.path.split('/')) + 1 if self.path else 1
 
         # get the subcategories
-        subcats = [e.category for e in self._subcats_recursive]
+        subcats = [e for e in self._subcats_recursive]
 
         # convert them into separated pathlists with only 'parts' parts
         subcats = [c.split('/')[:parts] for c in subcats]

--- a/publ/category.py
+++ b/publ/category.py
@@ -54,7 +54,6 @@ class Category:
         self.path = path
         self.basename = os.path.basename(path)
 
-        # pylint: disable=assignment-from-no-return
         subcat_query = orm.select(e.category for e in model.Entry)
         if path:
             subcat_query = orm.select(

--- a/publ/category.py
+++ b/publ/category.py
@@ -50,14 +50,14 @@ class Category:
         self.basename = os.path.basename(path)
 
         # pylint: disable=assignment-from-no-return
-        subcat_query = model.Entry.select(model.Entry.category).distinct()
+        subcat_query = orm.select(e.category for e in model.Entry)
         if path:
-            subcat_query = subcat_query.where(
-                model.Entry.category.startswith(path + '/'))
+            subcat_query = orm.select(
+                c for c in subcat_query if c.startswith(path + '/'))
         else:
-            subcat_query = subcat_query.where(model.Entry.category != '')
+            subcat_query = orm.select(c for c in subcat_query if c != '')
 
-        self._subcats_recursive = subcat_query.order_by(model.Entry.category)
+        self._subcats_recursive = subcat_query.order_by(lambda c: c)
 
         self.link = utils.CallableProxy(self._link)
 

--- a/publ/category.py
+++ b/publ/category.py
@@ -227,26 +227,25 @@ def scan_file(fullpath, relpath):
     if not meta:
         return True
 
-    with model.lock:
-        # update the category meta file mapping
-        category = meta.get('Category', os.path.dirname(relpath))
-        values = {
-            'category': category,
-            'file_path': fullpath,
-            'sort_name': meta.get('Sort-Name', '')
-        }
+    # update the category meta file mapping
+    category = meta.get('Category', os.path.dirname(relpath))
+    values = {
+        'category': category,
+        'file_path': fullpath,
+        'sort_name': meta.get('Sort-Name', '')
+    }
 
-        logger.debug("setting category %s to metafile %s", category, fullpath)
-        record = model.Category.get(category=category)
-        if record:
-            record.set(**values)
-        else:
-            record = model.Category(**values)
+    logger.debug("setting category %s to metafile %s", category, fullpath)
+    record = model.Category.get(category=category)
+    if record:
+        record.set(**values)
+    else:
+        record = model.Category(**values)
 
-        # update other relationships to the index
-        for alias in meta.get_all('Path-Alias', []):
-            path_alias.set_alias(alias, category=record)
+    # update other relationships to the index
+    for alias in meta.get_all('Path-Alias', []):
+        path_alias.set_alias(alias, category=record)
 
-        orm.commit()
+    orm.commit()
 
     return record

--- a/publ/config.py
+++ b/publ/config.py
@@ -6,7 +6,11 @@ from dateutil import tz
 
 # pylint: disable=invalid-name
 
-database = 'sqlite:///:memory:'
+database_config = {
+    'provider': 'sqlite',
+    'filename': ':memory:'
+}
+
 content_folder = 'content'
 template_folder = 'templates'
 static_folder = 'static'

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -347,11 +347,10 @@ def get_entry_id(entry, fullpath, assign_id):
     if not entry_id:
         # We still don't have an ID; generate one pseudo-randomly, based on the
         # entry file path. This approach averages around 0.25 collisions per ID
-        # generated while keeping the entry ID reasonably short. count*N+C
-        # averages 1/(N-1) collisions per ID.
+        # generated while keeping the entry ID reasonably short. In general,
+        # count*N averages 1/(N-1) collisions per ID.
 
-        # database=None is to shut up pylint
-        limit = max(10, model.Entry.select().count(database=None) * 5)
+        limit = max(10, orm.get(orm.count(e) for e in model.Entry) * 5)
         attempt = 0
 
         while not entry_id or model.Entry.get(id=entry_id):

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -452,8 +452,7 @@ def scan_file(fullpath, relpath, assign_id):
         record = model.Entry.get(id=entry_id)
         if record:
             logger.debug("Reusing existing entry %d", record.id)
-            for k, v in values.items():
-                record.__setattr__(k, v)
+            record.set(**values)
         else:
             record = model.Entry(id=entry_id, **values)
 

--- a/publ/entry.py
+++ b/publ/entry.py
@@ -275,9 +275,9 @@ class Entry:
         query = queries.build_query(spec)
         query = queries.where_before_entry(query, self._record)
 
-        for entry in query.order_by(orm.desc(model.Entry.local_date),
-                                    orm.desc(model.Entry.id))[:1]:
-            return entry
+        for record in query.order_by(orm.desc(model.Entry.local_date),
+                                     orm.desc(model.Entry.id))[:1]:
+            return Entry(record)
         return None
 
     def _next(self, **kwargs):
@@ -288,9 +288,9 @@ class Entry:
         query = queries.build_query(spec)
         query = queries.where_after_entry(query, self._record)
 
-        for entry in query.order_by(model.Entry.local_date,
-                                    model.Entry.id)[:1]:
-            return entry
+        for record in query.order_by(model.Entry.local_date,
+                                     model.Entry.id)[:1]:
+            return Entry(record)
         return None
 
     def get(self, name, default=None):

--- a/publ/image.py
+++ b/publ/image.py
@@ -645,6 +645,7 @@ def get_image(path, search_path):
 
         image = PIL.Image.open(file_path)
         values = {
+            'file_path': file_path,
             'checksum': md5.hexdigest(),
             'width': image.width,
             'height': image.height,
@@ -653,10 +654,9 @@ def get_image(path, search_path):
         }
         record = model.Image.get(file_path=file_path)
         if record:
-            for k, v in values.items():
-                record.__setattr__(k, v)
+            record.set(**values)
         else:
-            record = model.Image(file_path=file_path, **values)
+            record = model.Image(**values)
         orm.commit()
 
     return LocalImage(record)

--- a/publ/index.py
+++ b/publ/index.py
@@ -100,7 +100,7 @@ def set_fingerprint(fullpath, fingerprint=None):
                 file_path=fullpath, fingerprint=fingerprint)
         orm.commit()
     except FileNotFoundError:
-        model.FileFingerprint.delete().where(model.FileFingerprint.file_path == fullpath)
+        orm.delete(fp for fp in model.FileFingerprint if fp.file_path == fullpath)
 
 
 class IndexWatchdog(watchdog.events.PatternMatchingEventHandler):

--- a/publ/index.py
+++ b/publ/index.py
@@ -163,7 +163,7 @@ def scan_index(content_dir):
                 last_fingerprint = get_last_fingerprint(fullpath)
                 if fingerprint != last_fingerprint:
                     scan_file(fullpath, relpath, False)
-        except:
+        except:  # pylint:disable=bare-except
             logger.exception("Got error parsing directory %s", root)
 
     for root, _, files in os.walk(content_dir, followlinks=True):

--- a/publ/index.py
+++ b/publ/index.py
@@ -7,6 +7,7 @@ import concurrent.futures
 
 import watchdog.observers
 import watchdog.events
+from pony import orm
 
 from . import entry
 from . import model
@@ -76,10 +77,10 @@ def scan_file(fullpath, relpath, assign_id):
         set_fingerprint(fullpath)
 
 
+@orm.db_session
 def get_last_fingerprint(fullpath):
     """ Get the last known modification time for a file """
-    record = model.FileFingerprint.get_or_none(
-        model.FileFingerprint.file_path == fullpath)
+    record = model.FileFingerprint.get(file_path=fullpath)
     if record:
         return record.fingerprint
     return None

--- a/publ/markdown.py
+++ b/publ/markdown.py
@@ -151,31 +151,32 @@ def to_html(text, config, image_search_path):
 
 class TitleRenderer(HtmlRenderer):
     """ A renderer that is suitable for rendering out page titles and nothing else """
-    # pylint: disable=missing-docstring
 
     def __init__(self):
         super().__init__({}, [])
 
     @staticmethod
     def paragraph(content):
+        """ Passthrough """
         return content
 
     @staticmethod
     def list(content, is_ordered, is_block):
+        """ Passthrough """
         # pylint: disable=unused-argument
-        print('list', content, is_ordered, is_block)
         return content
 
     @staticmethod
     def listitem(content, is_ordered, is_block):
+        """ Just add the * back on """
         # pylint: disable=unused-argument
-        print('listitem', content, is_ordered, is_block)
         if not is_ordered:
             return '* ' + content
         raise ValueError("Not sure how we got here")
 
     @staticmethod
     def header(content, level):
+        """ Passthrough """
         # pylint: disable=unused-argument
         return content
 
@@ -183,7 +184,6 @@ class TitleRenderer(HtmlRenderer):
 class HTMLStripper(html.parser.HTMLParser):
     """ A utility class to strip HTML from a string; based on
     https://stackoverflow.com/a/925630/318857 """
-    # pylint: disable=missing-docstring,abstract-method
 
     def __init__(self):
         super().__init__()
@@ -194,10 +194,16 @@ class HTMLStripper(html.parser.HTMLParser):
         self.fed = []
 
     def handle_data(self, data):
+        """ Append the text data """
         self.fed.append(data)
 
     def get_data(self):
+        """ Concatenate the output """
         return ''.join(self.fed)
+
+    def error(self, message):
+        """ Deprecated, per https://bugs.python.org/issue31844 """
+        return message
 
 
 def render_title(text, markup=True, no_smartquotes=False):

--- a/publ/model.py
+++ b/publ/model.py
@@ -4,17 +4,14 @@
 from __future__ import absolute_import
 
 import logging
-import threading
 import datetime
 from enum import Enum
 
 from pony import orm
-from pony.orm.dbapiprovider import StrConverter
 
 from . import config
 
 db = orm.Database()  # pylint: disable=invalid-name
-lock = threading.Lock()  # pylint: disable=invalid-name
 
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
@@ -114,18 +111,17 @@ def setup():
                             version.int_value)
             else:
                 rebuild = False
-
-    except Exception as e:
-        logger.info("Got exception %s", e)
+    except:  # pylint:disable=bare-except
+        logger.exception("Error mapping schema")
 
     if rebuild:
         logger.info("Rebuilding schema")
         try:
             db.drop_all_tables(with_all_data=True)
             db.create_tables()
-        except Exception as e:
-            raise RuntimeError("Unable to change schema automatically; please " +
-                               "delete the existing database and try again.", e)
+        except:
+            raise RuntimeError("Unable to upgrade schema automatically; please " +
+                               "delete the existing database and try again.")
 
     with orm.db_session:
         if not GlobalConfig.get(key='schema_version'):

--- a/publ/model.py
+++ b/publ/model.py
@@ -59,7 +59,7 @@ class Entry(db.Entity):
     # The actual displayable date
     display_date = orm.Required(datetime.datetime)
 
-    slug_text = orm.Required(str)
+    slug_text = orm.Optional(str)
     entry_type = orm.Optional(str)
     redirect_url = orm.Optional(str)
     title = orm.Optional(str)
@@ -73,10 +73,9 @@ class Entry(db.Entity):
 class Category(db.Entity):
     """ Metadata for a category """
 
-    # optional because Pony treats '' as equivalent to NULL
-    category = orm.Optional(str, unique=True)
+    category = orm.Optional(str)
     file_path = orm.Required(str)
-    sort_name = orm.Required(str)
+    sort_name = orm.Optional(str)
 
     aliases = orm.Set("PathAlias")
 

--- a/publ/model.py
+++ b/publ/model.py
@@ -47,7 +47,7 @@ class FileFingerprint(db.Entity):
 class Entry(db.Entity):
     """ Indexed entry """
     file_path = orm.Required(str)
-    category = orm.Required(str)
+    category = orm.Optional(str)
     status = orm.Required(int)
 
     # UTC-normalized, for ordering and visibility

--- a/publ/model.py
+++ b/publ/model.py
@@ -19,7 +19,7 @@ lock = threading.Lock()  # pylint: disable=invalid-name
 logger = logging.getLogger(__name__)  # pylint: disable=invalid-name
 
 # schema version; bump this number if it changes
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 1
 
 
 class GlobalConfig(db.Entity):
@@ -60,7 +60,7 @@ class Entry(db.Entity):
     display_date = orm.Required(datetime.datetime)
 
     slug_text = orm.Required(str)
-    entry_type = orm.Required(str)
+    entry_type = orm.Optional(str)
     redirect_url = orm.Optional(str)
     title = orm.Optional(str)
 

--- a/publ/path_alias.py
+++ b/publ/path_alias.py
@@ -34,8 +34,8 @@ def set_alias(alias, **kwargs):
     if pa:
         for k, v in values.items():
             pa.__setattr__(k, v)
-        else:
-            pa = model.PathAlias(**values)
+    else:
+        pa = model.PathAlias(**values)
     orm.commit()
 
 

--- a/publ/path_alias.py
+++ b/publ/path_alias.py
@@ -48,7 +48,7 @@ def get_alias(path):
     """
     # pylint:disable=too-many-return-statements
 
-    record = model.PathAlias.get_or_none(model.PathAlias.path == path)
+    record = model.PathAlias.get(path=path)
 
     if not record:
         return None, None

--- a/publ/path_alias.py
+++ b/publ/path_alias.py
@@ -34,8 +34,10 @@ def set_alias(alias, **kwargs):
     if record:
         record.set(**values)
     else:
-        pa = model.PathAlias(**values)
+        record = model.PathAlias(**values)
     orm.commit()
+
+    return record
 
 
 @orm.db_session

--- a/publ/path_alias.py
+++ b/publ/path_alias.py
@@ -30,10 +30,9 @@ def set_alias(alias, **kwargs):
     if len(spec) > 1:
         values['template'] = spec[1]
 
-    pa = model.PathAlias.get(path=path)
-    if pa:
-        for k, v in values.items():
-            pa.__setattr__(k, v)
+    record = model.PathAlias.get(path=path)
+    if record:
+        record.set(**values)
     else:
         pa = model.PathAlias(**values)
     orm.commit()

--- a/publ/path_alias.py
+++ b/publ/path_alias.py
@@ -4,10 +4,12 @@
 from __future__ import absolute_import, with_statement
 
 from flask import url_for, redirect, current_app
+from pony import orm
 
 from . import model
 
 
+@orm.db_session
 def set_alias(alias, **kwargs):
     """ Set a path alias.
 
@@ -28,9 +30,16 @@ def set_alias(alias, **kwargs):
     if len(spec) > 1:
         values['template'] = spec[1]
 
-    model.PathAlias.replace(**values).execute()
+    pa = model.PathAlias.get(path=path)
+    if pa:
+        for k, v in values.items():
+            pa.__setattr__(k, v)
+        else:
+            pa = model.PathAlias(**values)
+    orm.commit()
 
 
+@orm.db_session
 def remove_alias(path):
     """ Remove a path alias.
 
@@ -38,7 +47,8 @@ def remove_alias(path):
 
     path -- the path to remove the alias of
     """
-    model.PathAlias.delete().where(model.PathAlias.path == path).execute()
+    orm.delete(p for p in model.PathAlias if p.path == path)
+    orm.commit()
 
 
 def get_alias(path):

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -19,8 +19,8 @@ def where_entry_visible(query, date=None):
 
     return orm.select(
         e for e in query
-        if e.status == model.PublishStatus.PUBLISHED.name or
-        (e.status == model.PublishStatus.SCHEDULED.name and
+        if e.status == model.PublishStatus.PUBLISHED.value or
+        (e.status == model.PublishStatus.SCHEDULED.value and
          (e.utc_date <= (date or arrow.utcnow().datetime))
          )
     )
@@ -31,8 +31,8 @@ def where_entry_visible_future(query):
 
     return orm.select(
         e for e in query
-        if e.status in (model.PublishStatus.PUBLISHED.name,
-                        model.PublishStatus.SCHEDULED.name))
+        if e.status in (model.PublishStatus.PUBLISHED.value,
+                        model.PublishStatus.SCHEDULED.value))
 
 
 def where_entry_category(query, category, recurse=False):

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -19,8 +19,8 @@ def where_entry_visible(query, date=None):
 
     return orm.select(
         e for e in query
-        if e.status == model.PublishStatus.PUBLISHED.value or
-        (e.status == model.PublishStatus.SCHEDULED.value and
+        if e.status == model.PublishStatus.PUBLISHED.name or
+        (e.status == model.PublishStatus.SCHEDULED.name and
          (e.utc_date <= (date or arrow.utcnow().datetime))
          )
     )
@@ -31,8 +31,8 @@ def where_entry_visible_future(query):
 
     return orm.select(
         e for e in query
-        if e.status in (model.PublishStatus.PUBLISHED.value,
-                        model.PublishStatus.SCHEDULED.value))
+        if e.status in (model.PublishStatus.PUBLISHED.name,
+                        model.PublishStatus.SCHEDULED.name))
 
 
 def where_entry_category(query, category, recurse=False):

--- a/publ/queries.py
+++ b/publ/queries.py
@@ -75,8 +75,8 @@ def where_after_entry(query, ref):
     return orm.select(
         e for e in query
         if e.local_date > ref.local_date or
-        (e.local_date == entry.local_date and
-         e.id > entry.id
+        (e.local_date == ref.local_date and
+         e.id > ref.id
          )
     )
 

--- a/publ/rendering.py
+++ b/publ/rendering.py
@@ -10,7 +10,7 @@ import base64
 import flask
 from flask import request, redirect, render_template, url_for
 import werkzeug.exceptions as http_error
-from pony.orm import db_session
+from pony import orm
 
 from . import config
 from . import path_alias
@@ -186,7 +186,7 @@ def render_exception(error):
     })
 
 
-@db_session
+@orm.db_session
 def render_path_alias(path):
     """ Render a known path-alias (used primarily for Dreamhost .php redirects) """
 
@@ -197,7 +197,7 @@ def render_path_alias(path):
 
 
 @cache.cached(key_prefix=caching.make_category_key, unless=index.in_progress)
-@db_session
+@orm.db_session
 def render_category(category='', template=None):
     """ Render a category page.
 
@@ -254,7 +254,7 @@ def render_category(category='', template=None):
 
 
 @cache.cached(key_prefix=caching.make_entry_key, unless=index.in_progress)
-@db_session
+@orm.db_session
 def render_entry(entry_id, slug_text='', category=''):
     """ Render an entry page.
 

--- a/publ/view.py
+++ b/publ/view.py
@@ -25,15 +25,15 @@ PAGINATION_SPECS = OFFSET_PRIORITY + PAGINATION_PRIORITY
 
 #: Ordering queries for different sort orders
 ORDER_BY = {
-    'newest': (lambda e: (orm.desc(model.Entry.local_date), orm.desc(model.Entry.id))),
-    'oldest': (lambda e: (model.Entry.local_date, model.Entry.id)),
-    'title': (lambda e: (model.Entry.title, model.Entry.id))
+    'newest': (orm.desc(model.Entry.local_date), orm.desc(model.Entry.id)),
+    'oldest': (model.Entry.local_date, model.Entry.id),
+    'title': (model.Entry.title, model.Entry.id)
 }
 
 REVERSE_ORDER_BY = {
-    'newest': (lambda e: (model.Entry.local_date, model.Entry.id)),
-    'oldest': (lambda e: (orm.desc(model.Entry.local_date), orm.desc(model.Entry.id))),
-    'title': (lambda e: (orm.desc(model.Entry.title), orm.desc(model.Entry.id)))
+    'newest': (model.Entry.local_date, model.Entry.id),
+    'oldest': (orm.desc(model.Entry.local_date), orm.desc(model.Entry.id)),
+    'title': (orm.desc(model.Entry.title), orm.desc(model.Entry.id))
 }
 
 
@@ -86,16 +86,16 @@ class View:
             elif self._order_by == 'newest':
                 self.spec['last'] = self.spec['start']
 
-        self._where = queries.build_query(spec)
-        # pylint:disable=assignment-from-no-return
-        self._query = model.Entry.select().where(self._where)
+        self._query = queries.build_query(spec)
 
         self.range = utils.CallableProxy(self._view_name)
 
-        if 'count' in spec:
-            self._query = self._query.limit(spec['count'])
+        self._query = self._query.order_by(*ORDER_BY[self._order_by])
 
-        self._entries = self._query.order_by(*ORDER_BY[self._order_by])
+        if 'count' in spec:
+            self._entries = self._query[:spec['count']]
+        else:
+            self._entries = self._query[:]
 
         self.link = utils.CallableProxy(self._link)
 

--- a/publ/view.py
+++ b/publ/view.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, with_statement
 import arrow
 import flask
 from werkzeug.utils import cached_property
+from pony import orm
 
 from . import model, utils, queries
 from .entry import Entry
@@ -23,17 +24,17 @@ PAGINATION_PRIORITY = ['date', 'count']
 PAGINATION_SPECS = OFFSET_PRIORITY + PAGINATION_PRIORITY
 
 #: Ordering queries for different sort orders
-# ORDER_BY = {
-#     'newest': [-model.Entry.local_date, -model.Entry.id],
-#     'oldest': [model.Entry.local_date, model.Entry.id],
-#     'title': [model.Entry.title, model.Entry.id]
-# }
+ORDER_BY = {
+    'newest': (lambda e: (orm.desc(model.Entry.local_date), orm.desc(model.Entry.id))),
+    'oldest': (lambda e: (model.Entry.local_date, model.Entry.id)),
+    'title': (lambda e: (model.Entry.title, model.Entry.id))
+}
 
-# REVERSE_ORDER_BY = {
-#     'newest': [model.Entry.local_date, model.Entry.id],
-#     'oldest': [-model.Entry.local_date, -model.Entry.id],
-#     'title': [-model.Entry.title, -model.Entry.id]
-# }
+REVERSE_ORDER_BY = {
+    'newest': (lambda e: (model.Entry.local_date, model.Entry.id)),
+    'oldest': (lambda e: (orm.desc(model.Entry.local_date), orm.desc(model.Entry.id))),
+    'title': (lambda e: (orm.desc(model.Entry.title), orm.desc(model.Entry.id)))
+}
 
 
 SPAN_FORMATS = {

--- a/publ/view.py
+++ b/publ/view.py
@@ -23,17 +23,17 @@ PAGINATION_PRIORITY = ['date', 'count']
 PAGINATION_SPECS = OFFSET_PRIORITY + PAGINATION_PRIORITY
 
 #: Ordering queries for different sort orders
-ORDER_BY = {
-    'newest': [-model.Entry.local_date, -model.Entry.id],
-    'oldest': [model.Entry.local_date, model.Entry.id],
-    'title': [model.Entry.title, model.Entry.id]
-}
+# ORDER_BY = {
+#     'newest': [-model.Entry.local_date, -model.Entry.id],
+#     'oldest': [model.Entry.local_date, model.Entry.id],
+#     'title': [model.Entry.title, model.Entry.id]
+# }
 
-REVERSE_ORDER_BY = {
-    'newest': [model.Entry.local_date, model.Entry.id],
-    'oldest': [-model.Entry.local_date, -model.Entry.id],
-    'title': [-model.Entry.title, -model.Entry.id]
-}
+# REVERSE_ORDER_BY = {
+#     'newest': [model.Entry.local_date, model.Entry.id],
+#     'oldest': [-model.Entry.local_date, -model.Entry.id],
+#     'title': [-model.Entry.title, -model.Entry.id]
+# }
 
 
 SPAN_FORMATS = {

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup(
         'Flask',
         'flask_caching',
         'arrow',
-        'peewee',
+        'pony',
         'misaka',
         'Pillow',
         'pygments',

--- a/tests/schemaTest.py
+++ b/tests/schemaTest.py
@@ -1,0 +1,9 @@
+import logging
+import os
+from publ import model, config
+
+logging.basicConfig(level=logging.INFO)
+
+config.database_config['filename'] = os.path.join(os.getcwd(), 'test.db')
+
+model.setup()

--- a/tests/schemaTest.py
+++ b/tests/schemaTest.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from pony import orm
 from publ import model, config
 
 logging.basicConfig(level=logging.INFO)
@@ -7,3 +8,18 @@ logging.basicConfig(level=logging.INFO)
 config.database_config['filename'] = os.path.join(os.getcwd(), 'test.db')
 
 model.setup()
+
+with orm.db_session:
+    cat = model.Category.get(category='test')
+    if not cat:
+        print("creating anew")
+        cat = model.Category(
+            category='test', file_path='path', sort_name='asdfadsf')
+    orm.commit()
+
+    print(cat.category, cat.file_path, cat.sort_name)
+
+    blank = model.Category.get(category='')
+    if not blank:
+        print("making fresh")
+        blank = model.Category(category='', file_path='blah', sort_name='asdf')


### PR DESCRIPTION
<!--

Thank you for submitting a pull request! Please provide enough information so
that we may review it.

For more information, see the `CONTRIBUTING` guide.

-->

## Summary

Replace peewee with Pony ORM; resolves #120 in a rather roundabout way

## Detailed description

Pony ORM is better in many ways than peewee. So we use it now.

## Developer/user impact

Different table name mappings means users will have to manually delete their databases. This also requires a config change.

## Test plan

Lots of hammering away and performance testing, mostly.
